### PR TITLE
Fix reading file contents from working directory

### DIFF
--- a/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
@@ -100,7 +100,7 @@ public abstract class AbstractGitIT {
       add.call();
     }
     PersonIdent ident = new PersonIdent("joe", "email@email.com", dateInMs, 0);
-    RevCommit commit = git.commit().setCommitter(ident).setMessage("msg").call();
+    RevCommit commit = git.commit().setCommitter(ident).setAuthor(ident).setMessage("msg").call();
     return commit.getName();
   }
 

--- a/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
@@ -1,0 +1,41 @@
+/*
+ * Git Files Blame
+ * Copyright (C) 2009-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BlobReaderIT extends AbstractGitIT {
+  @Test
+  public void loadText_whenWorkDirectoryAndFileDoesntExist_thenThrowISE() {
+    BlobReader reader = new BlobReader(git.getRepository());
+    ObjectReader objectReader = git.getRepository().newObjectReader();
+    FileCandidate fc = mock(FileCandidate.class);
+    when(fc.getBlob()).thenReturn(ObjectId.zeroId());
+    when(fc.getOriginalPath()).thenReturn("invalid");
+
+    Assert.assertThrows(IllegalStateException.class, () -> reader.loadText(objectReader, fc));
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/BlobReaderTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlobReaderTest.java
@@ -58,39 +58,4 @@ public class BlobReaderTest {
 
     assertThat(rawContent).isEqualTo(new RawText(rawText).getRawContent());
   }
-
-  @Test
-  public void loadText_whenUsingPath_thenReturnsContentFromFS() throws IOException {
-    File file = temp.newFile();
-    Repository repository = mock(Repository.class);
-    when(repository.getWorkTree()).thenReturn(file.getParentFile());
-    Files.writeString(file.toPath(), "test");
-    FileCandidate fc = mock(FileCandidate.class);
-    when(fc.getBlob()).thenReturn(ObjectId.zeroId());
-    when(fc.getOriginalPath()).thenReturn(file.getName());
-
-    byte[] rawContent = new BlobReader(repository).loadText(objectReader, fc).getRawContent();
-
-    assertThat(new String(rawContent, StandardCharsets.UTF_8)).isEqualTo("test");
-  }
-
-  @Test
-  public void loadText_whenUsingPathToSymbolicLink_thenReturnsContentFromLinkedFile() throws IOException {
-    File file = temp.newFile();
-    Files.writeString(file.toPath(), "test");
-
-    File link = new File(temp.getRoot(), "link");
-    File symbolicLink = Files.createSymbolicLink(link.toPath(), file.toPath()).toFile();
-
-    FileCandidate fc = mock(FileCandidate.class);
-    when(fc.getBlob()).thenReturn(ObjectId.zeroId());
-    when(fc.getOriginalPath()).thenReturn(symbolicLink.getName());
-
-    Repository repository = mock(Repository.class);
-    when(repository.getWorkTree()).thenReturn(temp.getRoot());
-
-    byte[] rawContent = new BlobReader(repository).loadText(objectReader, fc).getRawContent();
-
-    assertThat(new String(rawContent, StandardCharsets.UTF_8)).isEqualTo("test");
-  }
 }


### PR DESCRIPTION
The inputStream created by the FileTreeIterator has a filter which explains the difference.

I also added a few tests related to symlinks to ensure that they are simply ignored and that the behavior is the same as with jgit.