### PR TITLE
GFB-9: Update JGit to 7.2 supporting Git Worktree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
     withJavadocJar()
     withSourcesJar()

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ javadoc {
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.4.0.202211300538-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r'
     implementation 'org.slf4j:slf4j-api:1.7.36'
 
     testCompileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=org.sonarsource.git.blame
-version=1.2-SNAPSHOT
+version=2.0-SNAPSHOT
 description=A git command implemented with JGit that blames multiple files simultaneously
 projectTitle=git-files-blame


### PR DESCRIPTION
[GFB-9](https://sonarsource.atlassian.net/browse/GFB-9)

Also, Java 17 had to be updated as JGit 7.2 requires it - therefore a major version increase.

[GFB-9]: https://sonarsource.atlassian.net/browse/GFB-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ