### PR TITLE
GFB-41 Change Code Owners and Slack notif

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       publishToBinaries: true  # disabled by default
       mavenCentralSync: true   # disabled by default
-      slackChannel: ops-analysis-experience
+      slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration changes:**
  - Updated `CODEOWNERS` to assign the repository to `@sonarsource/code-quality-ci-experience-squad`.
  - Changed the `slackChannel` in `release.yml` from `ops-analysis-experience` to `ops-ci-experience`.

<sub>This will update automatically on new commits.</sub>