### PR TITLE
GFB-43 Fix BlameWithBareRepoIT flakiness on machines with init.defaultBranch=main

### DIFF
--- a/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class BlameWithBareRepoIT extends AbstractGitIT {
   @Before
   public void prepareForBare() throws IOException, GitAPIException, URISyntaxException {
     var bareDir = createNewTempFolder();
-    var bareGit = Git.init().setBare(true).setDirectory(bareDir.toFile()).call();
+    var bareGit = Git.init().setBare(true).setInitialBranch(Constants.MASTER).setDirectory(bareDir.toFile()).call();
 
     git.remoteAdd()
       .setName("origin")


### PR DESCRIPTION
The bare repo was created via Git.init(), which honors the user's global init.defaultBranch config, while the local repo (GitUtils.createRepository) always defaults to "master". When these diverge, HEAD on the bare repo points to a branch that never receives the push, causing NoHeadException and a NullPointerException. Pin the bare repo's initial branch explicitly so the test no longer depends on ambient git config.
