### PR TITLE
GFB-44 Update dependencies and migrate tests to JUnit 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ java {
 
 license {
     header = rootProject.file('HEADER')
-    strictCheck true
+    strictCheck = true
     encoding = 'UTF-8'
     mapping {
         java = 'SLASHSTAR_STYLE'
@@ -32,20 +32,21 @@ license {
 
 javadoc {
     options.encoding = 'UTF-8'
+    options.addStringOption('Xdoclint:all,-missing', '-quiet')
 }
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.4.0.202509020913-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r'
     implementation 'org.slf4j:slf4j-api:1.7.36'
 
     testCompileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.mockito:mockito-core:5.1.1'
+    testImplementation 'org.apache.commons:commons-lang3:3.20.0'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
+    testImplementation 'org.mockito:mockito-core:5.23.0'
 }
 
 apply plugin: 'java'
@@ -66,7 +67,7 @@ if (version.endsWith('-SNAPSHOT') && ext.buildNumber != null) {
 repositories {
     def repository = project.hasProperty('qa') ? 'sonarsource-qa' : 'sonarsource'
     maven {
-        url "https://repox.jfrog.io/repox/${repository}"
+        url = "https://repox.jfrog.io/repox/${repository}"
         // The environment variables ARTIFACTORY_PRIVATE_USERNAME and ARTIFACTORY_PRIVATE_PASSWORD are used on QA env (Jenkins)
         // On local box, please add artifactoryUsername and artifactoryPassword to ~/.gradle/gradle.properties
         def artifactoryUsername = System.env.'ARTIFACTORY_PRIVATE_USERNAME' ?: (project.hasProperty('artifactoryUsername') ? project.getProperty('artifactoryUsername') : '')
@@ -124,8 +125,8 @@ artifactory {
     publish {
         repository {
             repoKey = System.getenv('ARTIFACTORY_DEPLOY_REPO')
-            username = System.getenv('ARTIFACTORY_DEPLOY_USERNAME') ?: project.properties.artifactoryUsername
-            password = System.getenv('ARTIFACTORY_DEPLOY_PASSWORD') ?: project.properties.artifactoryPaswword
+            username = System.getenv('ARTIFACTORY_DEPLOY_USERNAME') ?: providers.gradleProperty("artifactoryUsername").orNull
+            password = System.getenv('ARTIFACTORY_DEPLOY_PASSWORD') ?: providers.gradleProperty("artifactoryPaswword").orNull
         }
         defaults {
             properties = [
@@ -175,11 +176,8 @@ signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    required {
-        def branch = System.getenv()["GITHUB_REF_NAME"]
-        return (branch == 'master' || branch ==~ 'branch-[\\d.]+') &&
-                gradle.taskGraph.hasTask(":artifactoryPublish")
-    }
+    def branch = System.getenv()["GITHUB_REF_NAME"]
+    required = (branch == 'master' || branch ==~ 'branch-[\\d.]+') && gradle.taskGraph.hasTask(":artifactoryPublish")
     sign publishing.publications
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,16 @@ dependencies {
 
     testCompileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.apache.commons:commons-lang3:3.20.0'
     testImplementation 'org.assertj:assertj-core:3.27.7'
     testImplementation 'org.mockito:mockito-core:5.23.0'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ artifactory {
         repository {
             repoKey = System.getenv('ARTIFACTORY_DEPLOY_REPO')
             username = System.getenv('ARTIFACTORY_DEPLOY_USERNAME') ?: providers.gradleProperty("artifactoryUsername").orNull
-            password = System.getenv('ARTIFACTORY_DEPLOY_PASSWORD') ?: providers.gradleProperty("artifactoryPaswword").orNull
+            password = System.getenv('ARTIFACTORY_DEPLOY_PASSWORD') ?: providers.gradleProperty("artifactoryPassword").orNull
         }
         defaults {
             properties = [

--- a/src/main/java/org/sonar/scm/git/blame/diff/DiffEntry.java
+++ b/src/main/java/org/sonar/scm/git/blame/diff/DiffEntry.java
@@ -459,7 +459,6 @@ public class DiffEntry {
 	/**
 	 * Whether the mark tree filter with the specified index matched during scan
 	 * or not, see {@link #scan(TreeWalk, boolean, TreeFilter...)}. Example:
-	 * <p>
 	 *
 	 * <pre>
 	 * TreeFilter filterA = ...;

--- a/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
@@ -20,6 +20,7 @@
 package org.sonar.scm.git.blame;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -34,22 +35,21 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.sonar.scm.git.GitUtils.createRepository;
 
-public abstract class AbstractGitIT {
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+abstract class AbstractGitIT {
+  @TempDir
+  Path tempDirRoot;
 
   protected Path baseDir;
   protected Git git;
   protected RepositoryBlameCommand blame;
 
-  @Before
-  public void prepare() throws IOException {
+  @BeforeEach
+  void prepare() throws IOException {
     baseDir = createNewTempFolder();
     git = createRepository(baseDir);
     blame = new RepositoryBlameCommand(git.getRepository());
@@ -120,6 +120,6 @@ public abstract class AbstractGitIT {
 
   protected Path createNewTempFolder() throws IOException {
     // This is needed for Windows, otherwise the created File point to invalid (shortened by Windows) temp folder path
-    return temp.newFolder().toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
+    return Files.createTempDirectory(tempDirRoot, "junit").toRealPath(LinkOption.NOFOLLOW_LINKS);
   }
 }

--- a/src/test/java/org/sonar/scm/git/blame/BlameResultTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameResultTest.java
@@ -22,16 +22,16 @@ package org.sonar.scm.git.blame;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BlameResultTest {
+class BlameResultTest {
 
   private static final Instant ANY_DATE = LocalDateTime.now().toInstant(ZoneOffset.UTC);
 
   @Test
-  public void saveBlameDataForFile_whenFileCandidateHasOneRegionWithTwoLines_thenFileBlameContainsTwoLines() {
+  void saveBlameDataForFile_whenFileCandidateHasOneRegionWithTwoLines_thenFileBlameContainsTwoLines() {
     BlameResult blameResult = new BlameResult();
 
     FileCandidate fileCandidate = new FileCandidate("path", "path", null);
@@ -45,7 +45,7 @@ public class BlameResultTest {
   }
 
   @Test
-  public void saveBlameDataForFile_whenFileCandidateHasTwoRegionsWithOneLineEach_thenFileBlameContainsTwoLines() {
+  void saveBlameDataForFile_whenFileCandidateHasTwoRegionsWithOneLineEach_thenFileBlameContainsTwoLines() {
     BlameResult blameResult = new BlameResult();
 
     FileCandidate fileCandidate = new FileCandidate("path", "path", null);

--- a/src/test/java/org/sonar/scm/git/blame/BlameThreadFactoryTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameThreadFactoryTest.java
@@ -19,14 +19,14 @@
  */
 package org.sonar.scm.git.blame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BlameThreadFactoryTest {
+class BlameThreadFactoryTest {
 
   @Test
-  public void newThread_whenRunnableIsNotNull_thenTheThreadNameContainsGitBlame() {
+  void newThread_whenRunnableIsNotNull_thenTheThreadNameContainsGitBlame() {
     BlameThreadFactory blameThreadFactory = new BlameThreadFactory();
 
     Thread thread = blameThreadFactory.newThread(System::currentTimeMillis);

--- a/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
@@ -26,20 +26,20 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.transport.URIish;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.sonar.scm.git.GitUtils.createFile;
 
-public class BlameWithBareRepoIT extends AbstractGitIT {
+class BlameWithBareRepoIT extends AbstractGitIT {
 
   private RepositoryBlameCommand bareRepoBlame;
 
-  @Before
-  public void prepareForBare() throws IOException, GitAPIException, URISyntaxException {
+  @BeforeEach
+  void prepareForBare() throws IOException, GitAPIException, URISyntaxException {
     var bareDir = createNewTempFolder();
     var bareGit = Git.init().setBare(true).setInitialBranch(Constants.MASTER).setDirectory(bareDir.toFile()).call();
 
@@ -56,7 +56,7 @@ public class BlameWithBareRepoIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenRemoteRepoIsBare() throws IOException, GitAPIException {
+  void blame_whenRemoteRepoIsBare() throws IOException, GitAPIException {
     createFile(baseDir, "file1", "line1", "line2");
     var c1 = commit("file1");
     push();
@@ -76,7 +76,7 @@ public class BlameWithBareRepoIT extends AbstractGitIT {
 
 
   @Test
-  public void getFileSize_noError() throws IOException, GitAPIException {
+  void getFileSize_noError() throws IOException, GitAPIException {
     createFile(baseDir, "file1", "line1");
     createFile(baseDir, "file2", "line1", "line2");
 

--- a/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
@@ -26,29 +26,29 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BlobReaderIT extends AbstractGitIT {
+class BlobReaderIT extends AbstractGitIT {
   @Test
-  public void loadText_whenWorkDirectoryAndFileDoesntExist_shouldThrowISE() {
+  void loadText_whenWorkDirectoryAndFileDoesntExist_shouldThrowISE() {
     BlobReader reader = new BlobReader(git.getRepository());
     ObjectReader objectReader = git.getRepository().newObjectReader();
     FileCandidate fc = mock(FileCandidate.class);
     when(fc.getBlob()).thenReturn(ObjectId.zeroId());
     when(fc.getOriginalPath()).thenReturn("invalid");
 
-    Assert.assertThrows(IllegalStateException.class, () -> reader.loadText(objectReader, fc));
+    assertThatThrownBy(() -> reader.loadText(objectReader, fc)).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  public void loadText_whenWorkDirectoryHasDirectories_shouldIgnoreDirs() throws IOException {
+  void loadText_whenWorkDirectoryHasDirectories_shouldIgnoreDirs() throws IOException {
     Path fileInDir = baseDir.resolve("dir/file");
     Files.createDirectories(fileInDir.getParent());
     Files.write(fileInDir, List.of("line1"));
@@ -61,7 +61,7 @@ public class BlobReaderIT extends AbstractGitIT {
   }
 
   @Test
-  public void getFileSize_noError() throws IOException {
+  void getFileSize_noError() throws IOException {
     Path file1 = baseDir.resolve("file1");
     Files.write(file1, List.of("line1"));
     Path file2 = baseDir.resolve("file2");

--- a/src/test/java/org/sonar/scm/git/blame/BlobReaderTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlobReaderTest.java
@@ -26,17 +26,17 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BlobReaderTest {
+class BlobReaderTest {
   private final ObjectReader objectReader = mock(ObjectReader.class);
 
   @Test
-  public void loadText_whenObjectExists_shouldReturnsNotEmptyObject() throws IOException {
+  void loadText_whenObjectExists_shouldReturnsNotEmptyObject() throws IOException {
     byte[] rawText = {51, 52, 53, 54, 55};
     ObjectId objectId = new ObjectId(1, 2, 3, 4, 5);
     ObjectLoader objectLoader = mock(ObjectLoader.class);

--- a/src/test/java/org/sonar/scm/git/blame/CommitGraphNodeTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/CommitGraphNodeTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.eclipse.jgit.lib.AbbreviatedObjectId;
 import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,10 +33,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonar.scm.git.blame.CommitGraphNode.TIME_COMPARATOR;
 
-public class CommitGraphNodeTest {
+class CommitGraphNodeTest {
 
   @Test
-  public void comparator_whenFakeCommit_thenIsLess() {
+  void comparator_whenFakeCommit_thenIsLess() {
     WorkDirGraphNode fakeCommit = new WorkDirGraphNode(null, List.of());
     CommitGraphNode commit = new CommitGraphNode(getRevCommit(2000), 1);
 
@@ -46,7 +46,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void comparator_whenTwoSimiliarCommits_thenOrderThemByTime() {
+  void comparator_whenTwoSimiliarCommits_thenOrderThemByTime() {
     CommitGraphNode earlyCommit = new CommitGraphNode(getRevCommit(1000), 1);
     CommitGraphNode laterCommit = new CommitGraphNode(getRevCommit(2000), 1);
 
@@ -56,7 +56,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void comparator_whenCommitsAreTheSame_thenOrderIsAlsoEqual() {
+  void comparator_whenCommitsAreTheSame_thenOrderIsAlsoEqual() {
     RevCommit revCommit = getRevCommit(1000);
     CommitGraphNode commitA = new CommitGraphNode(revCommit, 1);
     CommitGraphNode commitB = new CommitGraphNode(revCommit, 1);
@@ -67,7 +67,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void comparator_whenCommitsAreFromTheSameTime_thenOrderIsDependentOnUnderylingRevCommit() {
+  void comparator_whenCommitsAreFromTheSameTime_thenOrderIsDependentOnUnderylingRevCommit() {
     CommitGraphNode commitA = new CommitGraphNode(getRevCommit(1000), 1);
 
     RevCommit revCommit = getRevCommit(1000);
@@ -79,7 +79,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void getFilesByPath_whenKeyDoesntExist_thenReturnsEmptyCollection() {
+  void getFilesByPath_whenKeyDoesntExist_thenReturnsEmptyCollection() {
     CommitGraphNode underTest = new CommitGraphNode(getRevCommit(1000), 1);
 
     Collection<FileCandidate> emptyCollection = underTest.getFilesByPath("path");
@@ -88,7 +88,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void getFilesByPath_whenKeyDoesExist_thenReturnsNotEmptyCollection() {
+  void getFilesByPath_whenKeyDoesExist_thenReturnsNotEmptyCollection() {
     List<FileCandidate> fileCandidateList = List.of(fileCandidate("path"));
     CommitGraphNode underTest = new CommitGraphNode(getRevCommit(1000), fileCandidateList);
 
@@ -98,7 +98,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void addFile_whenFileAdded_thenItUpdatesBothCollections() {
+  void addFile_whenFileAdded_thenItUpdatesBothCollections() {
     CommitGraphNode underTest = new CommitGraphNode(getRevCommit(1000), 1);
 
     underTest.addFile(fileCandidate("path"));
@@ -108,7 +108,7 @@ public class CommitGraphNodeTest {
   }
 
   @Test
-  public void toString_whenCommitHasHash_thenPrintPartOfIt() {
+  void toString_whenCommitHasHash_thenPrintPartOfIt() {
     RevCommit revCommit = getRevCommit(1000);
     AbbreviatedObjectId shortId = mock(AbbreviatedObjectId.class);
     when(shortId.name()).thenReturn("abcdef");

--- a/src/test/java/org/sonar/scm/git/blame/FileBlamerTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FileBlamerTest.java
@@ -30,9 +30,10 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -43,7 +44,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonar.scm.git.blame.FileBlamer.NB_FILES_THRESHOLD_ONE_TREE_WALK;
 
-public class FileBlamerTest {
+class FileBlamerTest {
 
   private static final Instant ANY_DATE = LocalDateTime.now().toInstant(ZoneOffset.UTC);
   private static final Instant ANOTHER_DATE = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC);
@@ -56,8 +57,8 @@ public class FileBlamerTest {
   private final RevCommit revCommit = mock(RevCommit.class);
   private final FileCandidate fileCandidate = mock(FileCandidate.class);
 
-  @Before
-  public void before() {
+  @BeforeEach
+  void before() {
     when(revCommit.getName()).thenReturn(ANY_COMMIT_NAME);
 
     PersonIdent personIdent = mock(PersonIdent.class);
@@ -72,7 +73,7 @@ public class FileBlamerTest {
   }
 
   @Test
-  public void saveBlameDataForFilesInCommit_whenCommitContainsFileCandidate_thenCallBlameResult() {
+  void saveBlameDataForFilesInCommit_whenCommitContainsFileCandidate_thenCallBlameResult() {
     FileBlamer fileBlamer = new FileBlamer(null, null, null, null, blameResult, false);
     when(fileCandidate.getRegionList()).thenReturn(new Region(0, 0, 2));
 
@@ -85,7 +86,7 @@ public class FileBlamerTest {
   }
 
   @Test
-  public void initialize_thenInitializeBlameResultAndComparator() {
+  void initialize_thenInitializeBlameResultAndComparator() {
     FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, null, null, fileReader, blameResult, false);
 
     ObjectReader objectReader = mock(ObjectReader.class);
@@ -106,7 +107,7 @@ public class FileBlamerTest {
   }
 
   @Test
-  public void initializeWithLargeAmountOfFiles_thenInitializeBlameResultAndComparator() throws IOException {
+  void initializeWithLargeAmountOfFiles_thenInitializeBlameResultAndComparator() throws IOException {
     FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, null, null, fileReader, blameResult, false);
 
     ObjectReader objectReader = mock(ObjectReader.class);
@@ -123,8 +124,8 @@ public class FileBlamerTest {
     verify(fileTreeComparator).initialize(objectReader);
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void initializeWithLargeAmountOfFiles_throwsWhenError() throws IOException {
+  @Test
+  void initializeWithLargeAmountOfFiles_throwsWhenError() throws IOException {
     FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, null, null, fileReader, blameResult, false);
 
     ObjectReader objectReader = mock(ObjectReader.class);
@@ -133,11 +134,11 @@ public class FileBlamerTest {
 
     when(fileReader.getFileSizes(anySet())).thenThrow(new IOException());
 
-    fileBlamer.initialize(objectReader, statefulCommit);
+    assertThatThrownBy(() -> fileBlamer.initialize(objectReader, statefulCommit)).isInstanceOf(IllegalStateException.class);
   }
 
-  @Test (expected = IllegalStateException.class)
-  public void initializeWithLargeAmountOfFiles_throwsWhenFileNotInRepository() throws IOException {
+  @Test
+  void initializeWithLargeAmountOfFiles_throwsWhenFileNotInRepository() throws IOException {
     FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, null, null, fileReader, blameResult, false);
 
     int nbFilesInRepo = NB_FILES_THRESHOLD_ONE_TREE_WALK + 10;
@@ -151,7 +152,7 @@ public class FileBlamerTest {
     filesize.keySet().removeAll(filesize.keySet().stream().limit(1).collect(Collectors.toSet()));
     when(fileReader.getFileSizes(anySet())).thenReturn(filesize);
 
-    fileBlamer.initialize(objectReader, statefulCommit);
+    assertThatThrownBy(() -> fileBlamer.initialize(objectReader, statefulCommit)).isInstanceOf(IllegalStateException.class);
   }
 
   private static void addFileCandidates(int numberOfFiles, CommitGraphNode statefulCommit) {

--- a/src/test/java/org/sonar/scm/git/blame/FileCandidateTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FileCandidateTest.java
@@ -23,17 +23,17 @@ import java.util.stream.IntStream;
 import org.eclipse.jgit.diff.Edit;
 import org.eclipse.jgit.diff.EditList;
 import org.eclipse.jgit.lib.ObjectId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FileCandidateTest {
+class FileCandidateTest {
 
   private static final String ANY_PATH = "ANY";
   private static final ObjectId ANY_OBJECT_ID = ObjectId.fromRaw(new int[]{1,2,3,4,5});
 
   @Test
-  public void takeBlame_whenNoRegionLeft_thenDontAssignAnyRegion() {
+  void takeBlame_whenNoRegionLeft_thenDontAssignAnyRegion() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 
@@ -46,7 +46,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void takeBlame_whenEditNotInsideTheCandidateRegion_thenDontAssignAnyRegion() {
+  void takeBlame_whenEditNotInsideTheCandidateRegion_thenDontAssignAnyRegion() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     Region regionLeftToBlame = new Region(1, 0, 1);
@@ -66,7 +66,7 @@ public class FileCandidateTest {
    * 4e984bd7 (Author 2023-02-24 09:43:53 +0100 2) child commit
    */
   @Test
-  public void takeBlame_whenChildSingleLineEditAtTheEndOfFile_thenSplitBlame() {
+  void takeBlame_whenChildSingleLineEditAtTheEndOfFile_thenSplitBlame() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     child.setRegionList(new Region(0, 0, 2));
@@ -82,7 +82,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void takeBlame_whenEditExceedsRegion_thenParentsRegionShouldBeNull() {
+  void takeBlame_whenEditExceedsRegion_thenParentsRegionShouldBeNull() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     child.setRegionList(new Region(0, 0, 2));
@@ -97,7 +97,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void takeBlame_whenTwoEditsTenLinesEachInTheMiddleOfTheFile_thenChildAndParentShouldHaveTwoRegions() {
+  void takeBlame_whenTwoEditsTenLinesEachInTheMiddleOfTheFile_thenChildAndParentShouldHaveTwoRegions() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     child.setRegionList(new Region(0, 0, 100));
@@ -119,7 +119,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void takeBlame_whenManyContinuousEditsCoveringWholeFile_thenParentShouldNotHaveAnyRegionsLeft() {
+  void takeBlame_whenManyContinuousEditsCoveringWholeFile_thenParentShouldNotHaveAnyRegionsLeft() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     child.setRegionList(new Region(0, 0, 10));
@@ -134,7 +134,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void takeBlame_sequenceANotEqualToSequenceB_sourceStartInParentIsNegative() {
+  void takeBlame_sequenceANotEqualToSequenceB_sourceStartInParentIsNegative() {
     FileCandidate child = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate parent = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     child.setRegionList(new Region(0, 0, 10));
@@ -152,7 +152,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void mergeRegions_whenRegionsOverlappingAndStartAtTheSameLine_thenSecondRegionIsNull() {
+  void mergeRegions_whenRegionsOverlappingAndStartAtTheSameLine_thenSecondRegionIsNull() {
     FileCandidate first = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate second = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 
@@ -169,7 +169,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void mergeRegions_whenNoRegions_expectException() {
+  void mergeRegions_whenNoRegions_expectException() {
     FileCandidate first = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate second = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 
@@ -180,7 +180,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void mergeRegions_whenRegionsNotOverlappingAndStartAtTheSameLine_thenResultHasTwoRegions() {
+  void mergeRegions_whenRegionsNotOverlappingAndStartAtTheSameLine_thenResultHasTwoRegions() {
     FileCandidate first = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate second = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 
@@ -197,7 +197,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void mergeRegions_whenRegionsAreTheSame_thenResultHasTwoRegions() {
+  void mergeRegions_whenRegionsAreTheSame_thenResultHasTwoRegions() {
     FileCandidate first = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate second = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 
@@ -215,7 +215,7 @@ public class FileCandidateTest {
   }
 
   @Test
-  public void mergeRegions_whenOneRegionInsideAnother_thenResultHasTwoRegions() {
+  void mergeRegions_whenOneRegionInsideAnother_thenResultHasTwoRegions() {
     FileCandidate first = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
     FileCandidate second = new FileCandidate(ANY_PATH, ANY_PATH, ANY_OBJECT_ID);
 

--- a/src/test/java/org/sonar/scm/git/blame/FilteredRenameDetectorIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/FilteredRenameDetectorIT.java
@@ -27,8 +27,8 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.TreeFilter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.sonar.scm.git.blame.diff.DiffEntry;
 import org.sonar.scm.git.blame.diff.RenameDetector;
 
@@ -36,16 +36,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.sonar.scm.git.GitUtils.createFile;
 
-public class FilteredRenameDetectorIT extends AbstractGitIT {
+class FilteredRenameDetectorIT extends AbstractGitIT {
   private FilteredRenameDetector filteredRenameDetector;
 
-  @Before
-  public void before() {
+  @BeforeEach
+  void before() {
     filteredRenameDetector = new FilteredRenameDetector(new RenameDetector(git.getRepository()));
   }
 
   @Test
-  public void detectRenames_exact_rename_and_similar_rename_from_same_file() throws IOException, GitAPIException {
+  void detectRenames_exact_rename_and_similar_rename_from_same_file() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line2");
     String c1 = commit("fileA");
 

--- a/src/test/java/org/sonar/scm/git/blame/FilteredRenameDetectorTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FilteredRenameDetectorTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.scm.git.blame.diff.DiffEntry;
 import org.sonar.scm.git.blame.diff.RenameDetector;
 
@@ -32,12 +32,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class FilteredRenameDetectorTest {
+class FilteredRenameDetectorTest {
   private final RenameDetector renameDetector = mock(RenameDetector.class);
   private final FilteredRenameDetector filteredRenameDetector = new FilteredRenameDetector(renameDetector);
 
   @Test
-  public void detectRenames_whenChangesHaveAddsNotInPaths_thenFilterThem() throws IOException {
+  void detectRenames_whenChangesHaveAddsNotInPaths_thenFilterThem() throws IOException {
     DiffEntry addDiffEntry1 = mockedDiffEntry("pathA", DiffEntry.ChangeType.ADD);
     DiffEntry addDiffEntry2 = mockedDiffEntry("pathB", DiffEntry.ChangeType.ADD);
     Collection<DiffEntry> changes = Set.of(addDiffEntry1, addDiffEntry2);
@@ -47,7 +47,7 @@ public class FilteredRenameDetectorTest {
   }
 
   @Test
-  public void detectRenames_returns_results_of_renameDetector() throws IOException {
+  void detectRenames_returns_results_of_renameDetector() throws IOException {
     DiffEntry diffEntry1 = mockedDiffEntry("pathA", DiffEntry.ChangeType.ADD);
     DiffEntry diffEntry2 = mockedDiffEntry("pathB", DiffEntry.ChangeType.MODIFY);
     DiffEntry diffEntry3 = mockedDiffEntry("pathC", DiffEntry.ChangeType.DELETE);

--- a/src/test/java/org/sonar/scm/git/blame/GraphNodeFactoryIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/GraphNodeFactoryIT.java
@@ -27,18 +27,18 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.treewalk.TreeWalk;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.sonar.scm.git.GitUtils.createFile;
 
-public class GraphNodeFactoryIT extends AbstractGitIT {
+class GraphNodeFactoryIT extends AbstractGitIT {
 
   @Test
-  public void create_ignores_symlinks() throws IOException, GitAPIException {
-    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+  void create_ignores_symlinks() throws IOException, GitAPIException {
+    Assumptions.assumeFalse(SystemUtils.IS_OS_WINDOWS);
     String fileName = "fileA";
     String symlinkName = "symlink";
 
@@ -54,7 +54,7 @@ public class GraphNodeFactoryIT extends AbstractGitIT {
   }
 
   @Test
-  public void create_for_working_directory() throws IOException {
+  void create_for_working_directory() throws IOException {
     createFile(baseDir, "fileA", "line1");
     createFile(baseDir, "fileB", "line2");
 

--- a/src/test/java/org/sonar/scm/git/blame/GraphNodeFactoryTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/GraphNodeFactoryTest.java
@@ -24,19 +24,19 @@ import java.util.Set;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.treewalk.TreeWalk;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jgit.lib.FileMode.TYPE_FILE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GraphNodeFactoryTest {
+class GraphNodeFactoryTest {
   private final Repository repo = mock(Repository.class);
   private final RevCommit revCommit = mock(RevCommit.class);
 
   @Test
-  public void create_whenCommitNotIncludedInPathsToBlame_thenReturnNoFiles() throws IOException {
+  void create_whenCommitNotIncludedInPathsToBlame_thenReturnNoFiles() throws IOException {
     GraphNodeFactory statefulCommitFactory = new GraphNodeFactory(repo, Set.of("path"));
 
     TreeWalk treeWalk = mock(TreeWalk.class);
@@ -49,7 +49,7 @@ public class GraphNodeFactoryTest {
   }
 
   @Test
-  public void create_whenCommitIncludedInPathsToBlame_thenReturnOneFile() throws IOException {
+  void create_whenCommitIncludedInPathsToBlame_thenReturnOneFile() throws IOException {
     GraphNodeFactory statefulCommitFactory = new GraphNodeFactory(repo, Set.of("path"));
 
     TreeWalk treeWalk = mock(TreeWalk.class);
@@ -63,7 +63,7 @@ public class GraphNodeFactoryTest {
   }
 
   @Test
-  public void create_whenNoFilesToBlame_thenReturnOneFile() throws IOException {
+  void create_whenNoFilesToBlame_thenReturnOneFile() throws IOException {
     GraphNodeFactory statefulCommitFactory = new GraphNodeFactory(repo, null);
 
     TreeWalk treeWalk = mock(TreeWalk.class);

--- a/src/test/java/org/sonar/scm/git/blame/RegionTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/RegionTest.java
@@ -19,14 +19,14 @@
  */
 package org.sonar.scm.git.blame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RegionTest {
+class RegionTest {
 
   @Test
-  public void splitFirst_whenCalled_thenDontChangeResultStart() {
+  void splitFirst_whenCalled_thenDontChangeResultStart() {
     Region region = new Region(0, 1, 2);
 
     Region newRegion = region.splitFirst(3, 4);
@@ -36,7 +36,7 @@ public class RegionTest {
   }
 
   @Test
-  public void slideAndShrink_whenDifferenceIsPositiveInteger_thenReduceLength() {
+  void slideAndShrink_whenDifferenceIsPositiveInteger_thenReduceLength() {
     Region region = new Region(10, 10, 20);
 
     region.slideAndShrink(5);
@@ -46,7 +46,7 @@ public class RegionTest {
   }
 
   @Test
-  public void slideAndShrink_whenDifferenceIsZero_thenDontChangeTheObject() {
+  void slideAndShrink_whenDifferenceIsZero_thenDontChangeTheObject() {
     Region region = new Region(10, 10, 20);
 
     region.slideAndShrink(0);

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -336,7 +336,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
 
     MutableInt processedCommits = new MutableInt(0);
     blame.setProgressCallBack((iterationNb, commitHash) -> processedCommits.increment()).call();
-    assertThat(processedCommits.getValue())
+    assertThat(processedCommits.intValue())
       .as("We shouldn't process more commits than the total of commits in the repo")
       // work dir + 4 + 5
       .isLessThan(11);

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -32,7 +32,7 @@ import org.eclipse.jgit.api.BlameCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.RawTextComparator;
 import org.eclipse.jgit.lib.ConfigConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.scm.git.blame.BlameResult.FileBlame;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,9 +42,9 @@ import static org.sonar.scm.git.GitUtils.createFile;
 import static org.sonar.scm.git.GitUtils.deleteFile;
 import static org.sonar.scm.git.GitUtils.moveFile;
 
-public class RepositoryBlameCommandIT extends AbstractGitIT {
+class RepositoryBlameCommandIT extends AbstractGitIT {
   @Test
-  public void blame_whenCommittedSymlink_thenReturnNoBlame() throws IOException, GitAPIException {
+  void blame_whenCommittedSymlink_thenReturnNoBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
     Path link = Files.createSymbolicLink(baseDir.resolve("fileB"), baseDir.resolve("fileA"));
@@ -58,7 +58,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedSymlink_thenReturnNoBlame() throws IOException, GitAPIException {
+  void blame_whenUncommittedSymlink_thenReturnNoBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
     Path link = Files.createSymbolicLink(baseDir.resolve("fileB"), baseDir.resolve("fileA"));
@@ -71,7 +71,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedFiles_thenReadWorkingDirWithFilteredInputStream() throws IOException, GitAPIException {
+  void blame_whenUncommittedFiles_thenReadWorkingDirWithFilteredInputStream() throws IOException, GitAPIException {
     git.getRepository().getConfig().setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null, "safecrlf", true);
     git.getRepository().getConfig().setString(ConfigConstants.CONFIG_CORE_SECTION, null, "autocrlf", "input");
 
@@ -92,7 +92,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedFiles_thenThereIsNoBlame() throws IOException, GitAPIException {
+  void blame_whenUncommittedFiles_thenThereIsNoBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
 
@@ -104,7 +104,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedDeletedFiles_thenThereIsNoBlame() throws GitAPIException, IOException {
+  void blame_whenUncommittedDeletedFiles_thenThereIsNoBlame() throws GitAPIException, IOException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
 
@@ -116,7 +116,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedRenamedFiles_thenThereIsNoBlame() throws IOException, GitAPIException {
+  void blame_whenUncommittedRenamedFiles_thenThereIsNoBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
 
@@ -129,7 +129,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedLines_thenLinesHaveNullBlame() throws IOException, GitAPIException {
+  void blame_whenUncommittedLines_thenLinesHaveNullBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line3");
     String c1 = commit("fileA");
 
@@ -141,7 +141,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenUncommittedChangesIgnoredByTextComparator_thenHasNoEffectOnBlame() throws IOException, GitAPIException {
+  void blame_whenUncommittedChangesIgnoredByTextComparator_thenHasNoEffectOnBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line2");
     String c1 = commit("fileA");
 
@@ -154,7 +154,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenFileRenamedAndFileFilterUsed_thenDetectRename() throws IOException, GitAPIException {
+  void blame_whenFileRenamedAndFileFilterUsed_thenDetectRename() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     createFile(baseDir, "fileB", "line2");
     String c1 = commit("fileA", "fileB");
@@ -182,7 +182,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenFileMatchesTwoParents_thenPreferParentWithSameFilenameOverParentWithSameFileContent() throws GitAPIException, IOException {
+  void blame_whenFileMatchesTwoParents_thenPreferParentWithSameFilenameOverParentWithSameFileContent() throws GitAPIException, IOException {
     String c1 = commit();
 
     createFile(baseDir, "fileA", "line1", "line2");
@@ -217,7 +217,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * In this test, all regions should be moved to c4. Line1 should not be moved to c3.
    */
   @Test
-  public void blame_whenParentHasFileWithSameContent_thenFollowThatParent() throws IOException, GitAPIException {
+  void blame_whenParentHasFileWithSameContent_thenFollowThatParent() throws IOException, GitAPIException {
     String c1 = commit();
 
     createFile(baseDir, "fileA", "line1", "line3");
@@ -257,7 +257,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * In this test, all regions should be moved to c4. Line1 should not be moved to c3.
    */
   @Test
-  public void blame_whenParentHasHasRenamedFileWithSameContent_thenFollowThatParent() throws IOException, GitAPIException {
+  void blame_whenParentHasHasRenamedFileWithSameContent_thenFollowThatParent() throws IOException, GitAPIException {
     String c1 = commit();
 
     createFile(baseDir, "fileA", "line1", "line3");
@@ -284,7 +284,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenFilterUsed_thenOnlyBlameFilesInFilter() throws IOException, GitAPIException {
+  void blame_whenFilterUsed_thenOnlyBlameFilesInFilter() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     createFile(baseDir, "fileB", "line1");
     createFile(baseDir, "fileC", "line1");
@@ -310,7 +310,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenThereAreMultipleNodesInQueue_thenPickInReverseCommitTimeOrder() throws IOException, GitAPIException {
+  void blame_whenThereAreMultipleNodesInQueue_thenPickInReverseCommitTimeOrder() throws IOException, GitAPIException {
     long time = 10_000;
     createFile(baseDir, "fileA", "line1", "line2", "line3", "line4");
     String c1 = commit(time - 1000, "fileA");
@@ -346,7 +346,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * If there are no more parents, blame the commit for all remaining regions
    */
   @Test
-  public void blame_whenInitialCommitCreatedChanges_thenBlameInitialCommit() throws GitAPIException, IOException {
+  void blame_whenInitialCommitCreatedChanges_thenBlameInitialCommit() throws GitAPIException, IOException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
     BlameResult result = blame.call();
@@ -363,7 +363,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenThereIsRenameAndCopy_thenBlameOriginalFile() throws IOException, GitAPIException {
+  void blame_whenThereIsRenameAndCopy_thenBlameOriginalFile() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line2", "line3", "line4", "line5", "line6", "line7");
     String c1 = commit("fileA");
 
@@ -391,7 +391,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenFileBlameEndsInMultiplePathsWithARename_thenFinalPathMapsToMultiplePaths() throws IOException, GitAPIException {
+  void blame_whenFileBlameEndsInMultiplePathsWithARename_thenFinalPathMapsToMultiplePaths() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line2");
     createFile(baseDir, "fileB", "line3", "line4");
     String c1 = commitMsg("Create fileA and fileB", ".");
@@ -431,7 +431,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenFileBlameEndsInMultipleFiles_thenFinalPathMapsToMultiplePaths() throws IOException, GitAPIException {
+  void blame_whenFileBlameEndsInMultipleFiles_thenFinalPathMapsToMultiplePaths() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1", "line2");
     createFile(baseDir, "fileB", "line3", "line4");
     String c1 = commit(".");
@@ -470,7 +470,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
    * </pre>
    */
   @Test
-  public void blame_whenRegionsFromTwoCommitsEndInCommonParent_thenRegionsShouldBeMerged() throws GitAPIException, IOException {
+  void blame_whenRegionsFromTwoCommitsEndInCommonParent_thenRegionsShouldBeMerged() throws GitAPIException, IOException {
     createFile(baseDir, "fileA", "line1", "line2", "line3", "line4");
     String c1 = commit("fileA");
 
@@ -493,7 +493,7 @@ public class RepositoryBlameCommandIT extends AbstractGitIT {
   }
 
   @Test
-  public void blame_whenContentGiven_thenLinesHaveNullBlame() throws IOException, GitAPIException {
+  void blame_whenContentGiven_thenLinesHaveNullBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
     String unsavedContent = String.join(System.lineSeparator(), "line1", "newLine") + System.lineSeparator();

--- a/src/test/java/org/sonar/scm/git/blame/SameThreadExecutorServiceTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/SameThreadExecutorServiceTest.java
@@ -19,14 +19,14 @@
  */
 package org.sonar.scm.git.blame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SameThreadExecutorServiceTest {
+class SameThreadExecutorServiceTest {
 
   @Test
-  public void run_alwaysExecutesInTheSameThread() {
+  void run_alwaysExecutesInTheSameThread() {
     long expectedId = Thread.currentThread().getId();
     long[] threadId = new long[1];
 

--- a/src/test/java/org/sonar/scm/git/blame/WorkDirGraphNodeTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/WorkDirGraphNodeTest.java
@@ -21,41 +21,41 @@ package org.sonar.scm.git.blame;
 
 import java.util.List;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class WorkDirGraphNodeTest {
+class WorkDirGraphNodeTest {
   private final RevCommit commit = mock(RevCommit.class);
   private WorkDirGraphNode underTest;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     FileCandidate fc = mock(FileCandidate.class);
     when(fc.getPath()).thenReturn("path");
     underTest = new WorkDirGraphNode(commit, List.of(fc));
   }
 
   @Test
-  public void getCommit_returns_null() {
+  void getCommit_returns_null() {
     assertThat(underTest.getCommit()).isNull();
   }
 
   @Test
-  public void getParentCount_returns_one() {
+  void getParentCount_returns_one() {
     assertThat(underTest.getParentCount()).isOne();
   }
 
   @Test
-  public void getParent_returns_parent_commit() {
+  void getParent_returns_parent_commit() {
     assertThat(underTest.getParentCommit(0)).isEqualTo(commit);
   }
 
   @Test
-  public void getTime_returns_int_max() {
+  void getTime_returns_int_max() {
     assertThat(underTest.getTime()).isEqualTo(Integer.MAX_VALUE);
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Upgraded `org.eclipse.jgit` to `7.7.0.202606012155-r` and updated test dependencies including `commons-lang3`, `assertj-core`, and `mockito-core`.
- **Test framework migration:**
  - Migrated the test suite from JUnit 4 to JUnit 5, replacing `TemporaryFolder` with `@TempDir` and updating lifecycle annotations.
- **Build configuration:**
  - Modernized `build.gradle` by updating Artifactory credential retrieval to use `providers.gradleProperty` and refactored signing logic for compatibility.

<sub>This will update automatically on new commits.</sub>