### PR TITLE
GFB-46 Add a boundary-commit blame cache to short-circuit history traversal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,24 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'benchmark'
+    }
+}
+
+tasks.register('benchmark', Test) {
+    group = 'verification'
+    description = 'Runs performance benchmarks against synthetic large repositories (excluded from the default test task).'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform {
+        includeTags 'benchmark'
+    }
+    outputs.upToDateWhen { false }
+    testLogging {
+        showStandardStreams = true
+        events 'passed', 'skipped', 'failed', 'standardOut'
+    }
 }
 
 apply plugin: 'java'

--- a/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
@@ -54,13 +54,20 @@ public class BlameGenerator {
    */
   private final RevWalk revPool;
   private final BiConsumer<Integer, String> progressCallBack;
+  private final BoundaryBlame boundaryBlame;
 
   public BlameGenerator(Repository repository, FileBlamer fileBlamer, GraphNodeFactory graphNodeFactory, @Nullable BiConsumer<Integer, String> progressCallBack) {
+    this(repository, fileBlamer, graphNodeFactory, progressCallBack, null);
+  }
+
+  public BlameGenerator(Repository repository, FileBlamer fileBlamer, GraphNodeFactory graphNodeFactory, @Nullable BiConsumer<Integer, String> progressCallBack,
+    @Nullable BoundaryBlame boundaryBlame) {
     this.repository = repository;
     this.fileBlamer = fileBlamer;
     this.graphNodeFactory = graphNodeFactory;
     this.revPool = new RevWalk(repository);
     this.progressCallBack = progressCallBack;
+    this.boundaryBlame = boundaryBlame;
   }
 
   private void prepareStartCommit(@CheckForNull ObjectId startCommit) throws IOException, NoHeadException {
@@ -123,7 +130,11 @@ public class BlameGenerator {
         String hash = current.getCommit() == null ? ObjectId.zeroId().getName() : current.getCommit().getName();
         progressCallBack.accept(i, hash);
       }
-      if (current.getParentCount() > 0) {
+      if (isBoundaryCommit(current)) {
+        // reached the commit a previous analysis's blame was cached at: resolve remaining regions from that
+        // cache instead of walking further into history
+        fileBlamer.resolveFromBoundary(current, boundaryBlame);
+      } else if (current.getParentCount() > 0) {
         process(current);
       } else {
         // no more parents, so blame all remaining regions to the current commit
@@ -131,6 +142,10 @@ public class BlameGenerator {
       }
     }
     close();
+  }
+
+  private boolean isBoundaryCommit(GraphNode node) {
+    return boundaryBlame != null && node.getCommit() != null && node.getCommit().equals(boundaryBlame.getBoundaryCommit());
   }
 
   private void process(GraphNode commitCandidate) throws IOException {

--- a/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
@@ -131,14 +131,18 @@ public class BlameGenerator {
         progressCallBack.accept(i, hash);
       }
       if (isBoundaryCommit(current)) {
-        // reached the commit a previous analysis's blame was cached at: resolve remaining regions from that
-        // cache instead of walking further into history
+        // reached the commit a previous analysis's blame was cached at: resolve whichever files this cache
+        // covers directly from it. Files it doesn't cover (e.g. it was captured before they were last touched)
+        // keep their region list untouched, so the process()/leaf branch below still walks them further back.
         fileBlamer.resolveFromBoundary(current, boundaryBlame);
-      } else if (current.getParentCount() > 0) {
-        process(current);
-      } else {
-        // no more parents, so blame all remaining regions to the current commit
-        fileBlamer.saveBlameDataForFilesInCommit(current);
+      }
+      if (hasUnresolvedFiles(current)) {
+        if (current.getParentCount() > 0) {
+          process(current);
+        } else {
+          // no more parents, so blame all remaining regions to the current commit
+          fileBlamer.saveBlameDataForFilesInCommit(current);
+        }
       }
     }
     close();
@@ -146,6 +150,10 @@ public class BlameGenerator {
 
   private boolean isBoundaryCommit(GraphNode node) {
     return boundaryBlame != null && node.getCommit() != null && node.getCommit().equals(boundaryBlame.getBoundaryCommit());
+  }
+
+  private static boolean hasUnresolvedFiles(GraphNode node) {
+    return node.getAllFiles().stream().anyMatch(f -> f.getRegionList() != null);
   }
 
   private void process(GraphNode commitCandidate) throws IOException {

--- a/src/main/java/org/sonar/scm/git/blame/BlameResult.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameResult.java
@@ -44,16 +44,20 @@ public class BlameResult {
 
     Region currentRegion;
     while ((currentRegion = fileCandidate.getRegionList()) != null) {
-      int resLine = currentRegion.resultStart;
-      int resEnd = getResultEnd(currentRegion);
-
-      FileBlame fileBlame = fileBlameByPath.get(fileCandidate.getOriginalPath());
-      for (; resLine < resEnd; resLine++) {
-        fileBlame.commitHashes[resLine] = commitHash;
-        fileBlame.commitDates[resLine] = commitDate;
-        fileBlame.authorEmails[resLine] = authorEmail;
-      }
+      saveBlameDataForRange(fileCandidate.getOriginalPath(), currentRegion.resultStart, getResultEnd(currentRegion), commitHash, commitDate, authorEmail);
       fileCandidate.setRegionList(currentRegion.next);
+    }
+  }
+
+  /**
+   * Assigns the same attribution to every line in {@code [resultStart, resultEnd)} of the result file at {@code path}.
+   */
+  void saveBlameDataForRange(String path, int resultStart, int resultEnd, @Nullable String commitHash, @Nullable Instant commitDate, @Nullable String authorEmail) {
+    FileBlame fileBlame = fileBlameByPath.get(path);
+    for (int resLine = resultStart; resLine < resultEnd; resLine++) {
+      fileBlame.commitHashes[resLine] = commitHash;
+      fileBlame.commitDates[resLine] = commitDate;
+      fileBlame.authorEmails[resLine] = authorEmail;
     }
   }
 

--- a/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
+++ b/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
@@ -240,11 +240,13 @@ public final class BoundaryBlame {
 
   /**
    * Resolves every region still unblamed on {@code candidate} against this cache, consuming its region list.
+   * Does nothing, leaving the region list untouched, if this cache has no entry for the candidate's path - the
+   * caller is expected to fall back to walking that candidate's history normally in that case.
    */
   void resolveRegions(FileCandidate candidate, BlameResult blameResult) {
     List<Run> runs = runsByPath.get(candidate.getPath());
     if (runs == null) {
-      throw new IllegalStateException("No boundary blame was captured for path '" + candidate.getPath() + "' at commit " + boundaryCommit.getName());
+      return;
     }
 
     Region region = candidate.getRegionList();

--- a/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
+++ b/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
@@ -98,7 +98,11 @@ public final class BoundaryBlame {
     return runs;
   }
 
-  ObjectId getBoundaryCommit() {
+  /**
+   * The commit this cache was captured at. Callers use this to verify it's still an ancestor of the commit
+   * being blamed before passing this cache to {@link RepositoryBlameCommand#setBoundaryBlame(BoundaryBlame)}.
+   */
+  public ObjectId getBoundaryCommit() {
     return boundaryCommit;
   }
 

--- a/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
+++ b/src/main/java/org/sonar/scm/git/blame/BoundaryBlame.java
@@ -1,0 +1,308 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+
+/**
+ * A previously computed {@link BlameResult}, captured at a specific "boundary" commit and compacted into
+ * per-path runs of identical attribution. Passing this to {@link RepositoryBlameCommand#setBoundaryBlame(BoundaryBlame)}
+ * lets {@link BlameGenerator} stop walking history as soon as it reaches the boundary commit, resolving any
+ * regions still unblamed at that point directly from this cache instead of continuing into the boundary
+ * commit's own parents.
+ * <p>
+ * Only correct if the boundary commit is still an ancestor of the commit being blamed. Callers are responsible
+ * for checking that (e.g. no rebase/force-push/squash since the boundary was captured) before calling
+ * {@link RepositoryBlameCommand#setBoundaryBlame(BoundaryBlame)}.
+ */
+public final class BoundaryBlame {
+  private static final int MAGIC = 0x424F5544; // "BOUD"
+  private static final byte FORMAT_VERSION = 1;
+
+  private final ObjectId boundaryCommit;
+  private final Map<String, List<Run>> runsByPath;
+
+  private BoundaryBlame(ObjectId boundaryCommit, Map<String, List<Run>> runsByPath) {
+    this.boundaryCommit = boundaryCommit;
+    this.runsByPath = runsByPath;
+  }
+
+  /**
+   * @param boundaryCommit the commit at which {@code blameAtBoundary} was computed, i.e. the {@code startCommit}
+   *                        that was passed to the {@link RepositoryBlameCommand} that produced it
+   * @param blameAtBoundary a complete blame result computed with {@code setStartCommit(boundaryCommit)}
+   */
+  public static BoundaryBlame capture(AnyObjectId boundaryCommit, BlameResult blameAtBoundary) {
+    Map<String, List<Run>> runsByPath = new HashMap<>();
+    for (BlameResult.FileBlame fileBlame : blameAtBoundary.getFileBlames()) {
+      runsByPath.put(fileBlame.getPath(), compact(fileBlame));
+    }
+    return new BoundaryBlame(boundaryCommit.toObjectId(), runsByPath);
+  }
+
+  private static List<Run> compact(BlameResult.FileBlame fileBlame) {
+    String[] hashes = fileBlame.getCommitHashes();
+    Instant[] dates = fileBlame.getCommitDates();
+    String[] emails = fileBlame.getAuthorEmails();
+    int numberLines = fileBlame.lines();
+
+    List<Run> runs = new ArrayList<>();
+    int line = 0;
+    while (line < numberLines) {
+      int runStart = line;
+      String hash = hashes[line];
+      Instant date = dates[line];
+      String email = emails[line];
+      do {
+        line++;
+      } while (line < numberLines && Objects.equals(hashes[line], hash) && Objects.equals(dates[line], date) && Objects.equals(emails[line], email));
+      runs.add(new Run(runStart, line, hash, date, email));
+    }
+    return runs;
+  }
+
+  ObjectId getBoundaryCommit() {
+    return boundaryCommit;
+  }
+
+  /**
+   * Serializes this cache to {@code out}, e.g. to feed {@code WriteCache.write(key, InputStream)}. Does not close
+   * {@code out}; the caller controls its lifecycle.
+   */
+  public void writeTo(OutputStream out) throws IOException {
+    DataOutputStream data = new DataOutputStream(out);
+    data.writeInt(MAGIC);
+    data.writeByte(FORMAT_VERSION);
+    boundaryCommit.copyRawTo(data);
+
+    // commit metadata (hash/author/date) is repeated across many runs; store it once per distinct commit and have
+    // each run reference it by index
+    Map<String, Integer> commitIndexByHash = new LinkedHashMap<>();
+    Map<String, Run> firstRunByHash = new HashMap<>();
+    for (List<Run> runs : runsByPath.values()) {
+      for (Run run : runs) {
+        String hash = run.commitHash();
+        if (hash != null && commitIndexByHash.putIfAbsent(hash, commitIndexByHash.size()) == null) {
+          firstRunByHash.put(hash, run);
+        }
+      }
+    }
+
+    data.writeInt(commitIndexByHash.size());
+    for (String hash : commitIndexByHash.keySet()) {
+      Run representative = firstRunByHash.get(hash);
+      ObjectId.fromString(hash).copyRawTo(data);
+      writeNullableUTF(data, representative.authorEmail());
+      writeNullableLong(data, representative.commitDate() != null ? representative.commitDate().getEpochSecond() : null);
+    }
+
+    data.writeInt(runsByPath.size());
+    for (Map.Entry<String, List<Run>> entry : runsByPath.entrySet()) {
+      data.writeUTF(entry.getKey());
+      List<Run> runs = entry.getValue();
+      data.writeInt(runs.size());
+      for (Run run : runs) {
+        data.writeInt(run.start());
+        data.writeInt(run.endExclusive());
+        data.writeInt(run.commitHash() != null ? commitIndexByHash.get(run.commitHash()) : -1);
+      }
+    }
+    data.flush();
+  }
+
+  public byte[] toByteArray() {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try {
+      writeTo(bos);
+    } catch (IOException e) {
+      // ByteArrayOutputStream never throws
+      throw new UncheckedIOException(e);
+    }
+    return bos.toByteArray();
+  }
+
+  /**
+   * Parses a cache previously produced by {@link #writeTo(OutputStream)}, e.g. read from {@code ReadCache.read(key)}.
+   * Throws {@link IOException} on any format mismatch (including a version written by an incompatible release of
+   * this library) - callers should treat that as "no usable cache" and fall back to a full blame, the same as if
+   * the entry were simply absent.
+   */
+  public static BoundaryBlame readFrom(InputStream in) throws IOException {
+    DataInputStream data = new DataInputStream(in);
+    int magic = data.readInt();
+    if (magic != MAGIC) {
+      throw new IOException("Not a BoundaryBlame cache entry (unexpected header)");
+    }
+    byte version = data.readByte();
+    if (version != FORMAT_VERSION) {
+      throw new IOException("Unsupported BoundaryBlame cache format version: " + version);
+    }
+
+    byte[] rawId = new byte[Constants.OBJECT_ID_LENGTH];
+    data.readFully(rawId);
+    ObjectId boundaryCommit = ObjectId.fromRaw(rawId);
+
+    int numCommits = data.readInt();
+    String[] hashByIndex = new String[numCommits];
+    String[] emailByIndex = new String[numCommits];
+    Instant[] dateByIndex = new Instant[numCommits];
+    for (int i = 0; i < numCommits; i++) {
+      data.readFully(rawId);
+      hashByIndex[i] = ObjectId.fromRaw(rawId).getName();
+      emailByIndex[i] = readNullableUTF(data);
+      Long epochSecond = readNullableLong(data);
+      dateByIndex[i] = epochSecond != null ? Instant.ofEpochSecond(epochSecond) : null;
+    }
+
+    int numPaths = data.readInt();
+    Map<String, List<Run>> runsByPath = new HashMap<>(numPaths);
+    for (int p = 0; p < numPaths; p++) {
+      String path = data.readUTF();
+      int numRuns = data.readInt();
+      List<Run> runs = new ArrayList<>(numRuns);
+      for (int r = 0; r < numRuns; r++) {
+        int start = data.readInt();
+        int end = data.readInt();
+        int commitIndex = data.readInt();
+        runs.add(new Run(start, end, commitIndex >= 0 ? hashByIndex[commitIndex] : null, commitIndex >= 0 ? dateByIndex[commitIndex] : null,
+          commitIndex >= 0 ? emailByIndex[commitIndex] : null));
+      }
+      runsByPath.put(path, runs);
+    }
+
+    return new BoundaryBlame(boundaryCommit, runsByPath);
+  }
+
+  public static BoundaryBlame fromByteArray(byte[] bytes) throws IOException {
+    return readFrom(new ByteArrayInputStream(bytes));
+  }
+
+  private static void writeNullableUTF(DataOutputStream data, @Nullable String value) throws IOException {
+    data.writeBoolean(value != null);
+    if (value != null) {
+      data.writeUTF(value);
+    }
+  }
+
+  @Nullable
+  private static String readNullableUTF(DataInputStream data) throws IOException {
+    return data.readBoolean() ? data.readUTF() : null;
+  }
+
+  private static void writeNullableLong(DataOutputStream data, @Nullable Long value) throws IOException {
+    data.writeBoolean(value != null);
+    if (value != null) {
+      data.writeLong(value);
+    }
+  }
+
+  @Nullable
+  private static Long readNullableLong(DataInputStream data) throws IOException {
+    return data.readBoolean() ? data.readLong() : null;
+  }
+
+  /**
+   * Resolves every region still unblamed on {@code candidate} against this cache, consuming its region list.
+   */
+  void resolveRegions(FileCandidate candidate, BlameResult blameResult) {
+    List<Run> runs = runsByPath.get(candidate.getPath());
+    if (runs == null) {
+      throw new IllegalStateException("No boundary blame was captured for path '" + candidate.getPath() + "' at commit " + boundaryCommit.getName());
+    }
+
+    Region region = candidate.getRegionList();
+    while (region != null) {
+      resolveRegion(candidate.getOriginalPath(), region, runs, blameResult);
+      region = region.next;
+    }
+    candidate.setRegionList(null);
+  }
+
+  private static void resolveRegion(String originalPath, Region region, List<Run> runs, BlameResult blameResult) {
+    int sourceStart = region.sourceStart;
+    int sourceEnd = sourceStart + region.length;
+    int resultOffset = region.resultStart - sourceStart;
+
+    // runs are sorted and non-overlapping, so a single linear scan finds every run intersecting this region
+    for (Run run : runs) {
+      if (run.endExclusive() <= sourceStart) {
+        continue;
+      }
+      if (run.start() >= sourceEnd) {
+        break;
+      }
+      int overlapStart = Math.max(run.start(), sourceStart);
+      int overlapEnd = Math.min(run.endExclusive(), sourceEnd);
+      blameResult.saveBlameDataForRange(originalPath, overlapStart + resultOffset, overlapEnd + resultOffset, run.commitHash(), run.commitDate(), run.authorEmail());
+    }
+  }
+
+  public int getPathCount() {
+    return runsByPath.size();
+  }
+
+  public int getRunCount() {
+    return runsByPath.values().stream().mapToInt(List::size).sum();
+  }
+
+  /**
+   * The actual size of this cache once serialized via {@link #writeTo(OutputStream)}, alongside a breakdown useful
+   * to reason about where the bytes go.
+   */
+  public SerializedSize computeSerializedSize() {
+    Set<String> distinctCommits = new HashSet<>();
+    int runCount = 0;
+    for (List<Run> runs : runsByPath.values()) {
+      runCount += runs.size();
+      for (Run run : runs) {
+        if (run.commitHash() != null) {
+          distinctCommits.add(run.commitHash());
+        }
+      }
+    }
+    return new SerializedSize(runsByPath.size(), runCount, distinctCommits.size(), toByteArray().length);
+  }
+
+  public record SerializedSize(int pathCount, int runCount, int distinctCommitCount, long bytes) {
+  }
+
+  private record Run(int start, int endExclusive, @Nullable String commitHash, @Nullable Instant commitDate, @Nullable String authorEmail) {
+  }
+}

--- a/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
@@ -181,6 +181,18 @@ public class FileBlamer {
     return parentStatefulCommits;
   }
 
+  /**
+   * Resolves every file still unblamed on {@code source} directly from {@code boundary}, instead of walking into
+   * {@code source}'s parents. Only valid when {@code source} represents the exact commit {@code boundary} was captured at.
+   */
+  public void resolveFromBoundary(GraphNode source, BoundaryBlame boundary) {
+    for (FileCandidate sourceFile : source.getAllFiles()) {
+      if (sourceFile.getRegionList() != null) {
+        boundary.resolveRegions(sourceFile, blameResult);
+      }
+    }
+  }
+
   public void close() {
     executor.shutdown();
     try {

--- a/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
@@ -86,6 +86,7 @@ public class FileBlamer {
     for (FileCandidate fileCandidate : commit.getAllFiles()) {
       RawText rawText = fileReader.loadText(objectReader, fileCandidate);
       fileCandidate.setRegionList(new Region(0, 0, rawText.size()));
+      fileCandidate.setCachedText(rawText);
       blameResult.initialize(fileCandidate.getPath(), rawText.size());
     }
     fileTreeComparator.initialize(objectReader);
@@ -221,6 +222,8 @@ public class FileBlamer {
     // child's region could be null if it was already moved to another parent
     if (childFile.getRegionList() != null && parentPath != null) {
       FileCandidate parentFile = new FileCandidate(childFile.getOriginalPath(), parentPath, childFile.getBlob(), childFile.getRegionList());
+      // same content as childFile, so any cached text is still valid and can be reused at the next hop
+      parentFile.setCachedText(childFile.getCachedText());
       parent.addFile(parentFile);
       childFile.setRegionList(null);
     }
@@ -249,22 +252,35 @@ public class FileBlamer {
 
     if (parent.getBlob().equals(source.getBlob())) {
       moveUnmodifiedFileRegionsToParent(parent, source);
+      // same content, so the cached text (if any) is still valid for the parent
+      parent.setCachedText(source.getCachedText());
       return parent;
     }
 
     // ObjectReader is not thread safe, so we need to clone it
     ObjectReader reader = objectReader.newReader();
 
-    EditList editList = diffAlgorithm.diff(textComparator, fileReader.loadText(reader, parent), fileReader.loadText(reader, source));
+    // source's content was already read and cached when it was diffed as the parent of its child; a candidate is
+    // only ever diffed as the source once, so the cache can be consumed here and cleared
+    RawText sourceText = source.getCachedText() != null ? source.getCachedText() : fileReader.loadText(reader, source);
+    source.setCachedText(null);
+    RawText parentText = fileReader.loadText(reader, parent);
+
+    EditList editList = diffAlgorithm.diff(textComparator, parentText, sourceText);
     if (editList.isEmpty()) {
       // Ignoring whitespace (or some other special comparator) can cause non-identical blobs to have an empty edit list
       moveUnmodifiedFileRegionsToParent(parent, source);
+      parent.setCachedText(parentText);
       return parent;
     }
 
     parent.takeBlame(editList, source);
     // if the parent has nothing left to blame, don't return it
-    return parent.getRegionList() != null ? parent : null;
+    if (parent.getRegionList() == null) {
+      return null;
+    }
+    parent.setCachedText(parentText);
+    return parent;
   }
 
   private static void moveUnmodifiedFileRegionsToParent(FileCandidate parent, FileCandidate child) {

--- a/src/main/java/org/sonar/scm/git/blame/FileCandidate.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileCandidate.java
@@ -23,6 +23,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.eclipse.jgit.diff.Edit;
 import org.eclipse.jgit.diff.EditList;
+import org.eclipse.jgit.diff.RawText;
 import org.eclipse.jgit.lib.ObjectId;
 
 /**
@@ -46,6 +47,13 @@ class FileCandidate {
    * making it simple to merge-join with the sorted EditList during blame assignment.
    */
   private Region regionList;
+
+  /**
+   * Content of {@link #sourceBlob}, set when it was already read while this candidate was diffed as the
+   * "parent" side of an edit. Reused instead of re-reading the same blob when this candidate later becomes
+   * the "source" side of a diff against its own parent, since a candidate is diffed as the source at most once.
+   */
+  private RawText cachedText;
 
   FileCandidate(String originalPath, String path, ObjectId blob) {
     this(originalPath, path, blob, null);
@@ -77,6 +85,15 @@ class FileCandidate {
 
   public void setRegionList(@Nullable Region regionList) {
     this.regionList = regionList;
+  }
+
+  @CheckForNull
+  RawText getCachedText() {
+    return cachedText;
+  }
+
+  void setCachedText(@Nullable RawText cachedText) {
+    this.cachedText = cachedText;
   }
 
   void takeBlame(EditList editList, FileCandidate child) {

--- a/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
+++ b/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
@@ -48,6 +48,7 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
   private boolean multithreading = false;
   private BiConsumer<Integer, String> progressCallBack;
   private UnaryOperator<String> fileContentProvider = null;
+  private BoundaryBlame boundaryBlame = null;
 
   public RepositoryBlameCommand(Repository repo) {
     super(repo);
@@ -116,6 +117,18 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
     return this;
   }
 
+  /**
+   * If set, history traversal stops as soon as it reaches the boundary commit, and any regions still unblamed at
+   * that point are resolved from this cache instead of being blamed further back in history. Safe to set
+   * speculatively: if the boundary commit isn't an ancestor of the commit being blamed (e.g. it no longer is,
+   * after a rebase/force-push/squash since the cache was captured), traversal never reaches it, so this has no
+   * effect and blame falls back to walking full history.
+   */
+  public RepositoryBlameCommand setBoundaryBlame(@Nullable BoundaryBlame boundaryBlame) {
+    this.boundaryBlame = boundaryBlame;
+    return this;
+  }
+
   @Override
   public BlameResult call() throws GitAPIException {
     BlameResult blameResult = new BlameResult();
@@ -131,7 +144,7 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
       }
 
       GraphNodeFactory graphNodeFactory = new GraphNodeFactory(repo, filePaths);
-      BlameGenerator blameGenerator = new BlameGenerator(repo, fileBlamer, graphNodeFactory, progressCallBack);
+      BlameGenerator blameGenerator = new BlameGenerator(repo, fileBlamer, graphNodeFactory, progressCallBack, boundaryBlame);
       blameGenerator.generateBlame(startCommit);
     } catch (IOException e) {
       throw new IllegalStateException("Failed to blame repository files", e);

--- a/src/test/java/org/sonar/scm/git/blame/BoundaryBlameIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BoundaryBlameIT.java
@@ -21,6 +21,7 @@ package org.sonar.scm.git.blame;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Set;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.Test;
@@ -122,9 +123,33 @@ class BoundaryBlameIT extends AbstractGitIT {
     assertIncrementalMatchesFull(boundary);
   }
 
+  @Test
+  void incrementalBlame_matchesFullBlame_whenBoundaryCacheOnlyCoversSomeFiles() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1", "line2");
+    createFile(baseDir, "fileB", "other1", "other2");
+    String c1 = commit("fileA", "fileB");
+    createFile(baseDir, "fileA", "line1", "line2-v2");
+    createFile(baseDir, "fileB", "other1", "other2-v2");
+    String boundaryCommit = commit("fileA", "fileB");
+
+    // simulate a cache that was only ever populated for fileA - e.g. because a prior analysis only ended up
+    // blaming that one file - fileB has no entry at all
+    BoundaryBlame partialBoundary = captureBoundary(boundaryCommit, Set.of("fileA"));
+
+    createFile(baseDir, "fileA", "line1", "line2-v3");
+    createFile(baseDir, "fileB", "other1", "other2-v3");
+    commit("fileA", "fileB");
+
+    assertIncrementalMatchesFull(partialBoundary);
+  }
+
   private BoundaryBlame captureBoundary(String boundaryCommit) throws GitAPIException, IOException {
+    return captureBoundary(boundaryCommit, null);
+  }
+
+  private BoundaryBlame captureBoundary(String boundaryCommit, Set<String> filePaths) throws GitAPIException, IOException {
     ObjectId boundaryId = git.getRepository().resolve(boundaryCommit);
-    BlameResult blameAtBoundary = new RepositoryBlameCommand(git.getRepository()).setStartCommit(boundaryId).call();
+    BlameResult blameAtBoundary = new RepositoryBlameCommand(git.getRepository()).setStartCommit(boundaryId).setFilePaths(filePaths).call();
     BoundaryBlame captured = BoundaryBlame.capture(boundaryId, blameAtBoundary);
     return BoundaryBlame.fromByteArray(captured.toByteArray());
   }

--- a/src/test/java/org/sonar/scm/git/blame/BoundaryBlameIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BoundaryBlameIT.java
@@ -1,0 +1,163 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.sonar.scm.git.GitUtils.createFile;
+import static org.sonar.scm.git.GitUtils.deleteFile;
+import static org.sonar.scm.git.GitUtils.moveFile;
+
+/**
+ * Verifies that blaming with a {@link BoundaryBlame} cache produces the exact same result as a full blame,
+ * for the scenarios the short-circuit needs to get right: lines untouched since before the boundary, lines
+ * rewritten after the boundary, files renamed after the boundary, files added after the boundary, and files
+ * left completely untouched since before the boundary (moved to the boundary commit without ever being diffed).
+ * <p>
+ * Every scenario round-trips the cache through {@link BoundaryBlame#toByteArray()}/{@link BoundaryBlame#fromByteArray(byte[])}
+ * before using it, since that's how a real caller (e.g. reading it back from a {@code ReadCache}) would obtain it.
+ */
+class BoundaryBlameIT extends AbstractGitIT {
+
+  @Test
+  void incrementalBlame_matchesFullBlame_forLinesRewrittenAfterBoundary() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1", "line2", "line3");
+    String c1 = commit("fileA");
+    createFile(baseDir, "fileA", "line1", "line2-v2", "line3");
+    String boundaryCommit = commit("fileA");
+
+    BoundaryBlame boundary = captureBoundary(boundaryCommit);
+
+    createFile(baseDir, "fileA", "line1", "line2-v3", "line3");
+    String c3 = commit("fileA");
+
+    assertIncrementalMatchesFull(boundary);
+  }
+
+  @Test
+  void incrementalBlame_matchesFullBlame_forFileUntouchedSinceBeforeBoundary() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1", "line2");
+    String c1 = commit("fileA");
+    createFile(baseDir, "fileB", "other");
+    String boundaryCommit = commit("fileB");
+
+    BoundaryBlame boundary = captureBoundary(boundaryCommit);
+
+    // fileA isn't touched after the boundary; its FileCandidate should be moved unmodified all the way to the
+    // boundary commit and resolved from the cache without ever being diffed again
+    createFile(baseDir, "fileB", "other-v2");
+    commit("fileB");
+
+    assertIncrementalMatchesFull(boundary);
+  }
+
+  @Test
+  void incrementalBlame_matchesFullBlame_forFileRenamedAfterBoundary() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1", "line2", "line3");
+    String c1 = commit("fileA");
+    createFile(baseDir, "fileA", "line1", "line2-v2", "line3");
+    String boundaryCommit = commit("fileA");
+
+    BoundaryBlame boundary = captureBoundary(boundaryCommit);
+
+    moveFile(baseDir, "fileA", "fileA-renamed");
+    createFile(baseDir, "fileA-renamed", "line1", "line2-v2", "line3-v2");
+    rm("fileA");
+    commit("fileA-renamed");
+
+    assertIncrementalMatchesFull(boundary);
+  }
+
+  @Test
+  void incrementalBlame_matchesFullBlame_forFileAddedAfterBoundary() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1");
+    String boundaryCommit = commit("fileA");
+
+    BoundaryBlame boundary = captureBoundary(boundaryCommit);
+
+    createFile(baseDir, "fileB", "brand new file");
+    commit("fileB");
+
+    assertIncrementalMatchesFull(boundary);
+  }
+
+  @Test
+  void incrementalBlame_matchesFullBlame_forFileDeletedThenRecreatedAfterBoundary() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1", "line2");
+    String c1 = commit("fileA");
+    createFile(baseDir, "fileB", "other");
+    String boundaryCommit = commit("fileB");
+
+    BoundaryBlame boundary = captureBoundary(boundaryCommit);
+
+    deleteFile(baseDir, "fileA");
+    rm("fileA");
+    commit("fileA");
+    createFile(baseDir, "fileA", "brand new content");
+    commit("fileA");
+
+    assertIncrementalMatchesFull(boundary);
+  }
+
+  private BoundaryBlame captureBoundary(String boundaryCommit) throws GitAPIException, IOException {
+    ObjectId boundaryId = git.getRepository().resolve(boundaryCommit);
+    BlameResult blameAtBoundary = new RepositoryBlameCommand(git.getRepository()).setStartCommit(boundaryId).call();
+    BoundaryBlame captured = BoundaryBlame.capture(boundaryId, blameAtBoundary);
+    return BoundaryBlame.fromByteArray(captured.toByteArray());
+  }
+
+  @Test
+  void readFrom_whenNotABoundaryBlameCacheEntry_thenThrows() {
+    assertThatThrownBy(() -> BoundaryBlame.readFrom(new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5})))
+      .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void readFrom_whenFormatVersionIsNewer_thenThrows() throws IOException, GitAPIException {
+    createFile(baseDir, "fileA", "line1");
+    String boundaryCommit = commit("fileA");
+    ObjectId boundaryId = git.getRepository().resolve(boundaryCommit);
+    BlameResult blameAtBoundary = new RepositoryBlameCommand(git.getRepository()).setStartCommit(boundaryId).call();
+    byte[] serialized = BoundaryBlame.capture(boundaryId, blameAtBoundary).toByteArray();
+
+    // corrupt the format version byte (5th byte, right after the 4-byte magic header) to simulate a cache entry
+    // written by a future, incompatible version of this library
+    serialized[4] = Byte.MAX_VALUE;
+
+    assertThatThrownBy(() -> BoundaryBlame.fromByteArray(serialized))
+      .isInstanceOf(IOException.class)
+      .hasMessageContaining("version");
+  }
+
+  private void assertIncrementalMatchesFull(BoundaryBlame boundary) throws GitAPIException {
+    BlameResult fullResult = new RepositoryBlameCommand(git.getRepository()).call();
+    BlameResult incrementalResult = new RepositoryBlameCommand(git.getRepository()).setBoundaryBlame(boundary).call();
+
+    assertThat(incrementalResult.getFileBlameByPath())
+      .usingRecursiveComparison()
+      .isEqualTo(fullResult.getFileBlameByPath());
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/BoundaryBlameCacheSizeIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/BoundaryBlameCacheSizeIT.java
@@ -1,0 +1,88 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.BoundaryBlame;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+/**
+ * Not run as part of the default test task (see the "benchmark" Gradle task). Reports how big a {@link BoundaryBlame}
+ * cache would be for each of the synthetic scenarios in {@link RepositoryBlamePerfIT}, if it were captured at HEAD
+ * and persisted (e.g. in a sensor cache) for reuse by the next analysis.
+ */
+@Tag("benchmark")
+class BoundaryBlameCacheSizeIT {
+  private static final long SEED = 42L;
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void cacheSize_manyCommitsSmallFiles() throws IOException {
+    reportCacheSize(new SyntheticRepoGenerator.Config(300, 300, 3000, 2, SEED));
+  }
+
+  @Test
+  void cacheSize_fewCommitsLargeFiles() throws IOException {
+    reportCacheSize(new SyntheticRepoGenerator.Config(50, 5000, 2000, 3, SEED));
+  }
+
+  @Test
+  void cacheSize_veryLargeRepository() throws IOException {
+    reportCacheSize(new SyntheticRepoGenerator.Config(1000, 3000, 6000, 4, SEED));
+  }
+
+  @Test
+  void cacheSize_manyRenames() throws IOException {
+    reportCacheSize(new SyntheticRepoGenerator.Config(500, 500, 2000, 2, 40, 50, SEED));
+  }
+
+  private void reportCacheSize(SyntheticRepoGenerator.Config config) throws IOException {
+    Path repoDir = tempDir.resolve("repo.git");
+    SyntheticRepoGenerator.Stats stats = SyntheticRepoGenerator.generate(repoDir, config);
+
+    try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+      BlameResult blameAtHead = new RepositoryBlameCommand(repository).call();
+      BoundaryBlame boundary = BoundaryBlame.capture(stats.head(), blameAtHead);
+      BoundaryBlame.SerializedSize size = boundary.computeSerializedSize();
+
+      long totalLines = (long) stats.numFiles() * stats.linesPerFile();
+      double runsPerFile = (double) size.runCount() / size.pathCount();
+      double bytesPerLine = (double) size.bytes() / totalLines;
+
+      System.out.printf("Scenario: %d commits, %d files, %d lines/file (%d total lines)%n",
+        stats.numCommits(), stats.numFiles(), stats.linesPerFile(), totalLines);
+      System.out.printf("Cache: %d paths, %d runs (%.1f runs/file), %d distinct commits referenced%n",
+        size.pathCount(), size.runCount(), runsPerFile, size.distinctCommitCount());
+      System.out.printf("Serialized size: %.1f KB (%.3f bytes/line)%n%n", size.bytes() / 1024.0, bytesPerLine);
+    } catch (GitAPIException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/BoundaryBlameSpeedIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/BoundaryBlameSpeedIT.java
@@ -1,0 +1,132 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.BoundaryBlame;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Not run as part of the default test task (see the "benchmark" Gradle task). Compares blaming a repository from
+ * scratch against blaming it with a {@link BoundaryBlame} cache captured a few commits earlier, to measure whether
+ * the short-circuit actually pays off once a handful of new commits land on top of an already-blamed history.
+ */
+@Tag("benchmark")
+class BoundaryBlameSpeedIT {
+  private static final long SEED = 42L;
+  private static final long APPEND_SEED = 4242L;
+  private static final int WARMUP_RUNS = 1;
+  private static final int MEASURED_RUNS = 5;
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void speed_manyCommitsSmallFiles_fewExtraCommits() throws IOException, GitAPIException {
+    runScenario(new SyntheticRepoGenerator.Config(300, 300, 3000, 2, SEED), 20);
+  }
+
+  @Test
+  void speed_veryLargeRepository_fewExtraCommits() throws IOException, GitAPIException {
+    runScenario(new SyntheticRepoGenerator.Config(1000, 3000, 6000, 4, SEED), 20);
+  }
+
+  private void runScenario(SyntheticRepoGenerator.Config config, int extraCommits) throws IOException, GitAPIException {
+    Path repoDir = tempDir.resolve("repo.git");
+    SyntheticRepoGenerator.Stats boundaryStats = SyntheticRepoGenerator.generate(repoDir, config);
+
+    BoundaryBlame boundary;
+    try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+      BlameResult blameAtBoundary = new RepositoryBlameCommand(repository).call();
+      boundary = BoundaryBlame.capture(boundaryStats.head(), blameAtBoundary);
+    }
+
+    SyntheticRepoGenerator.appendCommits(repoDir, config, extraCommits, APPEND_SEED);
+    System.out.printf("Scenario: %d boundary commits + %d extra commits, %d files, %d lines/file%n",
+      boundaryStats.numCommits(), extraCommits, config.numFiles(), config.linesPerFile());
+
+    Measurement fullBlame = measure(repoDir, config.numFiles(), null);
+    Measurement incrementalBlame = measure(repoDir, config.numFiles(), boundary);
+
+    assertThat(incrementalBlame.lastResult().getFileBlameByPath())
+      .usingRecursiveComparison()
+      .isEqualTo(fullBlame.lastResult().getFileBlameByPath());
+
+    printSummary("Full blame       ", fullBlame.timingsMs());
+    printSummary("Incremental blame", incrementalBlame.timingsMs());
+    double speedup = median(fullBlame.timingsMs()) / (double) median(incrementalBlame.timingsMs());
+    System.out.printf("Speedup: %.1fx%n%n", speedup);
+  }
+
+  private Measurement measure(Path repoDir, int expectedNumFiles, @Nullable BoundaryBlame boundary) throws IOException {
+    List<Long> measuredMs = new ArrayList<>();
+    BlameResult lastResult = null;
+    for (int i = 0; i < WARMUP_RUNS + MEASURED_RUNS; i++) {
+      try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+        RepositoryBlameCommand command = new RepositoryBlameCommand(repository);
+        if (boundary != null) {
+          command.setBoundaryBlame(boundary);
+        }
+        long startNs = System.nanoTime();
+        lastResult = command.call();
+        long elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+        assertThat(lastResult.getFileBlames()).hasSize(expectedNumFiles);
+        if (i >= WARMUP_RUNS) {
+          measuredMs.add(elapsedMs);
+        }
+      } catch (GitAPIException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return new Measurement(measuredMs, lastResult);
+  }
+
+  private static void printSummary(String label, List<Long> measuredMs) {
+    List<Long> sorted = new ArrayList<>(measuredMs);
+    Collections.sort(sorted);
+    long min = sorted.get(0);
+    long median = median(sorted);
+    double avg = sorted.stream().mapToLong(Long::longValue).average().orElseThrow();
+    System.out.printf("%s over %d measured runs: min=%dms median=%dms avg=%.1fms%n", label, sorted.size(), min, median, avg);
+  }
+
+  private static long median(List<Long> measuredMs) {
+    List<Long> sorted = new ArrayList<>(measuredMs);
+    Collections.sort(sorted);
+    return sorted.get(sorted.size() / 2);
+  }
+
+  private record Measurement(List<Long> timingsMs, BlameResult lastResult) {
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/RepositoryBlamePerfIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/RepositoryBlamePerfIT.java
@@ -1,0 +1,138 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Not run as part of the default test task (see the "benchmark" Gradle task). Generates a synthetic repository
+ * and times {@link RepositoryBlameCommand} against it, to measure the impact of performance changes to the
+ * blame algorithm on a repository with a long history.
+ */
+@Tag("benchmark")
+class RepositoryBlamePerfIT {
+  private static final long SEED = 42L;
+
+  private static final int WARMUP_RUNS = 1;
+  private static final int MEASURED_RUNS = 5;
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * Many files, many commits, but each file is small. Representative of the per-commit tree-walk/bookkeeping
+   * overhead rather than blob loading cost.
+   */
+  @Test
+  void blame_wholeRepository_manyCommitsSmallFiles() throws IOException {
+    runScenario(new SyntheticRepoGenerator.Config(300, 300, 3000, 2, SEED));
+  }
+
+  /**
+   * Few files, but each one is large. Isolates the cost of loading and diffing blob content across history,
+   * since the per-commit tree-walk over a handful of files is comparatively cheap.
+   */
+  @Test
+  void blame_wholeRepository_fewCommitsLargeFiles() throws IOException {
+    runScenario(new SyntheticRepoGenerator.Config(50, 5000, 2000, 3, SEED));
+  }
+
+  /**
+   * Many files, each of them large, over a long history. Stresses both the per-commit tree-walk/bookkeeping
+   * overhead and blob loading/diffing cost at once, closer to what a big real-world monorepo looks like.
+   */
+  @Test
+  void blame_wholeRepository_veryLargeRepository() throws IOException {
+    runScenario(new SyntheticRepoGenerator.Config(1000, 3000, 6000, 4, SEED), 1, 3);
+  }
+
+  /**
+   * Periodic bursts renaming a chunk of the tracked files, each rename also rewriting a line so it can't be
+   * matched by exact blob id. This forces {@code RenameDetector} into its expensive content-similarity matching
+   * (an O(added x deleted) matrix build) on every burst commit, instead of the cheap linear paths exercised by
+   * the other scenarios, which never add or delete files.
+   */
+  @Test
+  void blame_wholeRepository_manyRenames() throws IOException {
+    runScenario(new SyntheticRepoGenerator.Config(500, 500, 2000, 2, 40, 50, SEED));
+  }
+
+  private void runScenario(SyntheticRepoGenerator.Config config) throws IOException {
+    runScenario(config, WARMUP_RUNS, MEASURED_RUNS);
+  }
+
+  private void runScenario(SyntheticRepoGenerator.Config config, int warmupRuns, int measuredRuns) throws IOException {
+    Path repoDir = tempDir.resolve("repo.git");
+
+    long generationStartNs = System.nanoTime();
+    SyntheticRepoGenerator.Stats stats = SyntheticRepoGenerator.generate(repoDir, config);
+    long generationMs = (System.nanoTime() - generationStartNs) / 1_000_000;
+    System.out.printf("Generated repo: %d commits, %d files, %d lines/file (%d ms)%n",
+      stats.numCommits(), stats.numFiles(), stats.linesPerFile(), generationMs);
+
+    List<Long> measuredMs = new ArrayList<>();
+    for (int i = 0; i < warmupRuns + measuredRuns; i++) {
+      long elapsedMs = runBlameAndMeasure(repoDir, config.numFiles());
+      if (i < warmupRuns) {
+        System.out.printf("Warmup run: %d ms%n", elapsedMs);
+      } else {
+        System.out.printf("Measured run %d: %d ms%n", i - warmupRuns + 1, elapsedMs);
+        measuredMs.add(elapsedMs);
+      }
+    }
+
+    printSummary(measuredMs);
+  }
+
+  private long runBlameAndMeasure(Path repoDir, int expectedNumFiles) throws IOException {
+    try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+      long startNs = System.nanoTime();
+      BlameResult result = new RepositoryBlameCommand(repository).call();
+      long elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+      assertThat(result.getFileBlames()).hasSize(expectedNumFiles);
+      return elapsedMs;
+    } catch (GitAPIException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static void printSummary(List<Long> measuredMs) {
+    List<Long> sorted = new ArrayList<>(measuredMs);
+    Collections.sort(sorted);
+    long min = sorted.get(0);
+    long median = sorted.get(sorted.size() / 2);
+    double avg = sorted.stream().mapToLong(Long::longValue).average().orElseThrow();
+    System.out.printf("Summary over %d measured runs: min=%dms median=%dms avg=%.1fms%n", sorted.size(), min, median, avg);
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
@@ -1,0 +1,202 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jgit.lib.CommitBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.TreeFormatter;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+/**
+ * Generates a synthetic bare repository directly through JGit's low-level object database APIs (no working tree,
+ * no porcelain add/commit), so that repositories with thousands of commits can be built in a few seconds.
+ * Each commit modifies a handful of existing files by rewriting one line, which is representative of the
+ * incremental history a real blame run has to walk.
+ */
+public final class SyntheticRepoGenerator {
+
+  private SyntheticRepoGenerator() {
+  }
+
+  /**
+   * @param filesRenamedPerCommit how many files get renamed (with a one-line content change, so the rename can't be
+   *                              matched by exact blob id and forces content-similarity matching) on commits where a
+   *                              rename burst happens
+   * @param renameBurstEveryNCommits a rename burst happens every N commits; ignored if filesRenamedPerCommit is 0
+   */
+  public record Config(int numFiles, int linesPerFile, int numCommits, int filesModifiedPerCommit, int filesRenamedPerCommit, int renameBurstEveryNCommits,
+    long seed) {
+
+    public Config(int numFiles, int linesPerFile, int numCommits, int filesModifiedPerCommit, long seed) {
+      this(numFiles, linesPerFile, numCommits, filesModifiedPerCommit, 0, 1, seed);
+    }
+  }
+
+  /**
+   * Statistics about the generated repository, returned so a benchmark can print context alongside timings.
+   */
+  public record Stats(int numFiles, int linesPerFile, int numCommits, ObjectId head) {
+  }
+
+  public static Stats generate(Path bareRepoDir, Config config) throws IOException {
+    Repository repository = new FileRepositoryBuilder().setGitDir(bareRepoDir.toFile()).build();
+    repository.create(true);
+
+    try (repository; ObjectInserter inserter = repository.newObjectInserter()) {
+      Random random = new Random(config.seed());
+
+      List<String> paths = new ArrayList<>(List.of(buildSortedFileNames(config.numFiles())));
+      Map<String, String[]> linesByPath = new HashMap<>();
+      Map<String, ObjectId> blobByPath = new HashMap<>();
+      for (String path : paths) {
+        String[] lines = initialLines(path, config.linesPerFile());
+        linesByPath.put(path, lines);
+        blobByPath.put(path, insertBlob(inserter, lines));
+      }
+      AtomicInteger renameCounter = new AtomicInteger();
+
+      ObjectId parentCommit = null;
+      Instant commitTime = Instant.parse("2015-01-01T00:00:00Z");
+      for (int commitIdx = 0; commitIdx < config.numCommits(); commitIdx++) {
+        for (int modIdx = 0; modIdx < config.filesModifiedPerCommit(); modIdx++) {
+          String path = paths.get(random.nextInt(paths.size()));
+          rewriteRandomLine(inserter, linesByPath, blobByPath, path, random, commitIdx);
+        }
+
+        if (config.filesRenamedPerCommit() > 0 && commitIdx % config.renameBurstEveryNCommits() == 0) {
+          for (int renIdx = 0; renIdx < config.filesRenamedPerCommit(); renIdx++) {
+            renameRandomFile(inserter, paths, linesByPath, blobByPath, random, commitIdx, renameCounter);
+          }
+        }
+
+        ObjectId treeId = buildTree(inserter, paths, blobByPath);
+        PersonIdent ident = new PersonIdent("generator", "generator@example.com", commitTime, ZoneOffset.UTC);
+        parentCommit = createCommit(inserter, treeId, parentCommit, ident, "commit " + commitIdx);
+        commitTime = commitTime.plusSeconds(60);
+      }
+
+      inserter.flush();
+      pointHeadTo(repository, parentCommit);
+      return new Stats(config.numFiles(), config.linesPerFile(), config.numCommits(), parentCommit);
+    }
+  }
+
+  private static void rewriteRandomLine(ObjectInserter inserter, Map<String, String[]> linesByPath, Map<String, ObjectId> blobByPath, String path,
+    Random random, int commitIdx) throws IOException {
+    String[] lines = linesByPath.get(path);
+    int lineIdx = random.nextInt(lines.length);
+    lines[lineIdx] = "commit " + commitIdx + " rewrote line " + lineIdx + " of " + path;
+    blobByPath.put(path, insertBlob(inserter, lines));
+  }
+
+  /**
+   * Renames a randomly picked file to a brand-new path, rewriting one of its lines at the same time so the new
+   * blob can't be matched to the old one by exact id, forcing the (expensive) content-similarity rename matching.
+   */
+  private static void renameRandomFile(ObjectInserter inserter, List<String> paths, Map<String, String[]> linesByPath, Map<String, ObjectId> blobByPath,
+    Random random, int commitIdx, AtomicInteger renameCounter) throws IOException {
+    int idx = random.nextInt(paths.size());
+    String oldPath = paths.get(idx);
+    String[] lines = linesByPath.remove(oldPath);
+    blobByPath.remove(oldPath);
+
+    String newPath = String.format("renamed-%06d.txt", renameCounter.getAndIncrement());
+    int lineIdx = random.nextInt(lines.length);
+    lines[lineIdx] = "commit " + commitIdx + " renamed " + oldPath + " to " + newPath + " and rewrote line " + lineIdx;
+
+    paths.set(idx, newPath);
+    linesByPath.put(newPath, lines);
+    blobByPath.put(newPath, insertBlob(inserter, lines));
+  }
+
+  private static String[] buildSortedFileNames(int numFiles) {
+    String[] names = new String[numFiles];
+    int digits = Integer.toString(Math.max(numFiles - 1, 1)).length();
+    for (int i = 0; i < numFiles; i++) {
+      names[i] = String.format("file%0" + digits + "d.txt", i);
+    }
+    return names;
+  }
+
+  private static String[] initialLines(String path, int linesPerFile) {
+    String[] lines = new String[linesPerFile];
+    for (int i = 0; i < linesPerFile; i++) {
+      lines[i] = path + " initial line " + i;
+    }
+    return lines;
+  }
+
+  private static ObjectId insertBlob(ObjectInserter inserter, String[] lines) throws IOException {
+    byte[] content = (String.join("\n", lines) + "\n").getBytes(StandardCharsets.UTF_8);
+    return inserter.insert(Constants.OBJ_BLOB, content);
+  }
+
+  private static ObjectId buildTree(ObjectInserter inserter, List<String> paths, Map<String, ObjectId> blobByPath) throws IOException {
+    String[] sortedPaths = paths.toArray(new String[0]);
+    Arrays.sort(sortedPaths);
+
+    TreeFormatter treeFormatter = new TreeFormatter();
+    for (String path : sortedPaths) {
+      treeFormatter.append(path, FileMode.REGULAR_FILE, blobByPath.get(path));
+    }
+    return inserter.insert(treeFormatter);
+  }
+
+  private static ObjectId createCommit(ObjectInserter inserter, ObjectId treeId, ObjectId parentId, PersonIdent ident, String message) throws IOException {
+    CommitBuilder commitBuilder = new CommitBuilder();
+    commitBuilder.setTreeId(treeId);
+    if (parentId != null) {
+      commitBuilder.addParentId(parentId);
+    }
+    commitBuilder.setAuthor(ident);
+    commitBuilder.setCommitter(ident);
+    commitBuilder.setMessage(message);
+    return inserter.insert(commitBuilder);
+  }
+
+  private static void pointHeadTo(Repository repository, ObjectId head) throws IOException {
+    String branchRef = Constants.R_HEADS + Constants.MASTER;
+
+    RefUpdate branchUpdate = repository.updateRef(branchRef);
+    branchUpdate.setNewObjectId(head);
+    branchUpdate.forceUpdate();
+
+    RefUpdate headUpdate = repository.updateRef(Constants.HEAD);
+    headUpdate.link(branchRef);
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
@@ -36,11 +36,15 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.TreeFormatter;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.TreeWalk;
 
 /**
  * Generates a synthetic bare repository directly through JGit's low-level object database APIs (no working tree,
@@ -114,6 +118,78 @@ public final class SyntheticRepoGenerator {
       pointHeadTo(repository, parentCommit);
       return new Stats(config.numFiles(), config.linesPerFile(), config.numCommits(), parentCommit);
     }
+  }
+
+  /**
+   * Appends {@code extraCommits} more commits on top of an existing repository previously produced by {@link #generate},
+   * following the same "modify a handful of random files" pattern. Reads the current state (paths, blobs, line content)
+   * back from the repository itself rather than requiring any in-memory generation state to be kept around, so it can be
+   * used to simulate a few commits landing on top of a repository that was already blamed (and cached) in a separate run.
+   */
+  public static ObjectId appendCommits(Path bareRepoDir, Config config, int extraCommits, long seed) throws IOException {
+    Repository repository = new FileRepositoryBuilder().setGitDir(bareRepoDir.toFile()).build();
+
+    try (repository; ObjectInserter inserter = repository.newObjectInserter(); ObjectReader reader = repository.newObjectReader()) {
+      ObjectId headId = repository.resolve(Constants.HEAD);
+      RevCommit headCommit;
+      try (RevWalk revWalk = new RevWalk(reader)) {
+        headCommit = revWalk.parseCommit(headId);
+      }
+
+      List<String> paths = new ArrayList<>();
+      Map<String, String[]> linesByPath = new HashMap<>();
+      Map<String, ObjectId> blobByPath = new HashMap<>();
+      readExistingTree(reader, headCommit, paths, linesByPath, blobByPath);
+
+      Random random = new Random(seed);
+      AtomicInteger renameCounter = new AtomicInteger();
+      ObjectId parentCommit = headId;
+      Instant commitTime = Instant.ofEpochSecond(headCommit.getCommitTime()).plusSeconds(60);
+
+      for (int commitIdx = 0; commitIdx < extraCommits; commitIdx++) {
+        for (int modIdx = 0; modIdx < config.filesModifiedPerCommit(); modIdx++) {
+          String path = paths.get(random.nextInt(paths.size()));
+          rewriteRandomLine(inserter, linesByPath, blobByPath, path, random, commitIdx);
+        }
+
+        if (config.filesRenamedPerCommit() > 0 && commitIdx % config.renameBurstEveryNCommits() == 0) {
+          for (int renIdx = 0; renIdx < config.filesRenamedPerCommit(); renIdx++) {
+            renameRandomFile(inserter, paths, linesByPath, blobByPath, random, commitIdx, renameCounter);
+          }
+        }
+
+        ObjectId treeId = buildTree(inserter, paths, blobByPath);
+        PersonIdent ident = new PersonIdent("generator", "generator@example.com", commitTime, ZoneOffset.UTC);
+        parentCommit = createCommit(inserter, treeId, parentCommit, ident, "extra commit " + commitIdx);
+        commitTime = commitTime.plusSeconds(60);
+      }
+
+      inserter.flush();
+      pointHeadTo(repository, parentCommit);
+      return parentCommit;
+    }
+  }
+
+  private static void readExistingTree(ObjectReader reader, RevCommit commit, List<String> paths, Map<String, String[]> linesByPath,
+    Map<String, ObjectId> blobByPath) throws IOException {
+    try (TreeWalk treeWalk = new TreeWalk(reader)) {
+      treeWalk.addTree(commit.getTree());
+      treeWalk.setRecursive(true);
+      while (treeWalk.next()) {
+        String path = treeWalk.getPathString();
+        ObjectId blobId = treeWalk.getObjectId(0);
+        paths.add(path);
+        blobByPath.put(path, blobId);
+        linesByPath.put(path, readLines(reader, blobId));
+      }
+    }
+  }
+
+  private static String[] readLines(ObjectReader reader, ObjectId blobId) throws IOException {
+    String content = new String(reader.open(blobId).getBytes(), StandardCharsets.UTF_8);
+    String[] lines = content.split("\n", -1);
+    // insertBlob always terminates the content with a trailing '\n', which split() turns into a trailing empty element
+    return lines.length > 0 && lines[lines.length - 1].isEmpty() ? Arrays.copyOf(lines, lines.length - 1) : lines;
   }
 
   private static void rewriteRandomLine(ObjectInserter inserter, Map<String, String[]> linesByPath, Map<String, ObjectId> blobByPath, String path,

--- a/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
@@ -148,9 +148,14 @@ public final class SyntheticRepoGenerator {
     String[] names = new String[numFiles];
     int digits = Integer.toString(Math.max(numFiles - 1, 1)).length();
     for (int i = 0; i < numFiles; i++) {
-      names[i] = String.format("file%0" + digits + "d.txt", i);
+      names[i] = "file" + zeroPad(i, digits) + ".txt";
     }
     return names;
+  }
+
+  private static String zeroPad(int value, int digits) {
+    String raw = Integer.toString(value);
+    return "0".repeat(Math.max(0, digits - raw.length())) + raw;
   }
 
   private static String[] initialLines(String path, int linesPerFile) {


### PR DESCRIPTION
## Summary
- Adds `BoundaryBlame`: a previously computed blame result captured at a given "boundary" commit, compacted into per-path RLE runs, that `RepositoryBlameCommand.setBoundaryBlame(...)` can use to stop history traversal as soon as it reaches that commit instead of walking further back.
- `BoundaryBlame` serializes to a compact binary format (`writeTo`/`readFrom`, `toByteArray`/`fromByteArray`), so it can be persisted between analyses - e.g. written to/read from a scanner sensor cache. Callers are responsible for verifying the boundary commit is still an ancestor of the commit being blamed; if it isn't, the short-circuit simply never triggers and blame falls back to walking full history.
- Extends the synthetic benchmark harness (`SyntheticRepoGenerator.appendCommits`) to simulate a few new commits landing on top of an already-blamed repository, and adds two benchmarks: cache size across the existing scenarios, and full-vs-incremental blame timing.

Stacked on `jh/blame-perf-blob-cache` (#106) rather than `master`, so this review stays scoped to the new boundary-cache work.

## Benchmark results
Cache size (captured at HEAD for each synthetic scenario), well under 1 MB even for the largest repo:

| Scenario | Files x lines | Serialized size | Bytes/line |
|---|---|---|---|
| many commits, small files | 300 x 300 | 294 KB | 3.34 |
| few commits, large files | 50 x 5000 | 242 KB | 0.99 |
| very large repo | 1000 x 3000 | 896 KB | 0.31 |
| many renames | 500 x 500 | 248 KB | 1.01 |

Full vs incremental blame, after appending 20 commits on top of an already-blamed history (results verified identical on every run):
- 3000 commits / 300 files: 731ms -> 98ms (7.5x)
- 6000 commits / 1000 files: 7889ms -> 828ms (9.5x)

## Test plan
- [x] `./gradlew test` passes (including new correctness tests in `BoundaryBlameIT`: lines rewritten/untouched/renamed/added/deleted-then-recreated after the boundary, plus two serialization format-safety tests)
- [x] `./gradlew benchmark --tests "*BoundaryBlame*"` passes and reports the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)