### PR TITLE
GFB-48 Scope tree diff to the blamed subfolder instead of a file-count threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,78 @@ In the event where we want to blame multiple files, we would need to call this c
 
 Our tool propose to blame every file simultaneously, traversing the commit graph only once and saving the cost of operations that are normally done for each file.
 
+## Optimizations compared to native git blame
+
+The sections below describe how this library diverges from a plain `git blame` (or looping
+JGit's `BlameCommand` over each file) to stay fast on large repositories and monorepos.
+
+### One commit traversal for all files
+
+This is the core idea. Native blame walks the whole history once *per file*; blaming _N_ files
+means _N_ independent walks that each re-parse commits, re-open trees and re-run diffs. This
+library walks the commit graph a **single** time, carrying the set of not-yet-blamed regions of
+every file backwards together. Work that native blame repeats per file — parsing each commit,
+loading trees, tree diffing, rename detection — is done once per commit hop and shared across
+all blamed files.
+
+### Patched JGit rename detection (the `diff` package)
+
+Five classes under `org.sonar.scm.git.blame.diff` are copied from JGit to apply a fix that was
+never merged upstream (the original Gerrit link is dead). Upstream JGit can report a single
+deleted file as the rename source of *several* added files; when blaming many files at once,
+that would make more than one file follow its history back to the same origin and corrupt the
+result. The fix keeps the first match a `RENAME` and turns the rest into `COPY`. Full rationale
+and the exact patch — kept in-repo so it survives the dead link — are in
+[docs/jgit-rename-detector-fork.md](docs/jgit-rename-detector-fork.md).
+
+### Rename detection restricted to the blamed files
+
+`FilteredRenameDetector` narrows JGit's rename detection to only the files being blamed: added
+files whose new path isn't among the blamed paths are dropped before rename scoring runs.
+Rename detection is the most expensive step of a diff (content-similarity matching is roughly
+quadratic in the number of adds × deletes), so restricting the destination set to what we
+actually care about avoids a large amount of pointless similarity scoring.
+
+### Reuse of blob content already read
+
+Every file candidate's blob used to be read and line-split twice: once as the *parent* side of
+an edit (or at the initial HEAD load) and again when the same object became the *source* side of
+the diff at the next commit hop. The `RawText` is now cached on the candidate when read as the
+parent/HEAD side and reused at the next hop. Measured **22–44% faster** on blob-loading-bound
+histories (bigger gain the larger the files), negligible on rename-heavy ones.
+
+### Path-scoped tree diff
+
+When every blamed file lives under a common subfolder (e.g. analyzing one module of a monorepo),
+the per-commit diff is scoped to that subfolder so JGit skips whole unchanged subtrees instead of
+computing the full-repository diff and running rename detection over it. The decision is made
+once from the request — whether the blamed files share a common subfolder — rather than from a
+file-count threshold, so it still triggers when thousands of files are blamed as long as they are
+a small slice of a much bigger tree.
+
+### Path-scoped walk and merge-aware rename fallback
+
+Two further exact optimizations kick in automatically when all blamed files share a common
+subfolder:
+
+- **Path-scoped walk** (`PathScopedWalk`): chains of single-parent commits whose subfolder tree
+  is unchanged are collapsed, so commits that never touch the blamed subfolder are never enqueued
+  or diffed. Big win on linear histories (JDK `src/java.xml`: ~51k → ~7k commit iterations).
+- **Merge-aware rename fallback**: the expensive full-repository diff + rename detection that
+  runs when a blamed file looks *added* is the real bottleneck on merge-heavy repositories. At a
+  merge it is now skipped for a parent when the added file is carried unchanged by another parent
+  (which claims its regions before any diff splitting, so the fallback result couldn't affect the
+  blame anyway). Linux `net/ethtool`: ~100s → ~5s.
+
+Both are exact — verified line-for-line against the unscoped walk — and merges that genuinely
+combine subfolder changes still run the full fallback.
+
+### Optional multithreading
+
+`setMultithreading(true)` parallelizes the per-file work within each commit (diffing each
+modified file against its parent blob) across a thread pool sized to the available processors.
+The commit traversal itself stays single-threaded; only the independent per-file splits fan out.
+
 ## Have Question or Feedback?
 
 For support questions ("How do I?", "I got this error, why?", ...), please first read the [documentation](https://docs.sonarqube.org) and then head to the [SonarSource Community](https://community.sonarsource.com/c/help/sq/10). The answer to your question has likely already been answered! 🤓

--- a/docs/jgit-rename-detector-fork.md
+++ b/docs/jgit-rename-detector-fork.md
@@ -1,0 +1,83 @@
+# Forked JGit rename-detection classes
+
+The package `org.sonar.scm.git.blame.diff` contains five classes copied verbatim from JGit:
+
+| Copy | Upstream original |
+| --- | --- |
+| `RenameDetector` | `org.eclipse.jgit.diff.RenameDetector` |
+| `SimilarityRenameDetector` | `org.eclipse.jgit.diff.SimilarityRenameDetector` |
+| `DiffEntry` | `org.eclipse.jgit.diff.DiffEntry` |
+| `ContentSource` | `org.eclipse.jgit.diff.ContentSource` |
+| `SimilarityIndex` | `org.eclipse.jgit.diff.SimilarityIndex` |
+
+Each carries the header `Copied from JGit to apply the fix https://git.eclipse.org/r/c/jgit/jgit/+/200218/1 / Do not modify it`.
+
+## Why they are copied
+
+JGit's rename detection lives in package-private classes (`SimilarityRenameDetector`,
+`SimilarityIndex`) and constructs itself around a package-private `RenameDetector` state. To
+apply a fix that upstream never merged (Gerrit change 200218, whose link is now dead), the
+whole cluster had to be duplicated into a package we own: `RenameDetector` needs the patched
+`SimilarityRenameDetector`, which needs `SimilarityIndex` and `ContentSource`, and all of them
+speak in terms of `DiffEntry`. They are kept byte-for-byte identical to upstream except for
+the fix below, so re-syncing against a newer JGit stays mechanical — hence the "Do not modify
+it" header.
+
+Note that `FilteredRenameDetector` (in the parent package, **not** copied — it is ours) wraps
+the forked `RenameDetector` to restrict rename detection to the blamed paths; see the README.
+
+## The fix (Gerrit 200218): one deleted source must not become several renames
+
+Upstream JGit can pair a single **deleted** source with several **added** destinations and
+report *every* pairing as a `RENAME`. For a normal one-file diff that never surfaces, but this
+library blames many files at once, so several blamed destinations can legitimately match the
+same deleted blob. Reporting each as a RENAME makes more than one blamed file follow its
+history back to the same deleted origin, corrupting the blame result.
+
+The fix makes the **first** pairing of a given deleted source a `RENAME` and every subsequent
+pairing of that same source a `COPY`, and removes each deleted entry from the leftover set only
+once. Concretely, relative to pristine JGit:
+
+### `RenameDetector`
+
+- New field tracking which deleted (source) paths a rename has already consumed:
+  ```java
+  // Old paths of deleted that have been matched in renames. If the corresponding
+  // deleted are matched again with other added, they'll be considered to be copies
+  // instead of renames.
+  private Set<String> matchedDeletedPaths;
+  ```
+- `reset()` initializes it (`matchedDeletedPaths = new HashSet<>();`).
+- `findExactRenames()` records the source path each time it emits an exact rename (the
+  one-add/one-delete, one-add/many-deletes and many-adds/many-deletes branches), and in the
+  many-to-many branch uses `matchedDeletedPaths.add(...)` to decide `RENAME` vs `COPY`.
+- `findContentRenames()` passes the shared set into the similarity detector:
+  `new SimilarityRenameDetector(reader, deleted, added, matchedDeletedPaths)`.
+- `compute()` drops the consumed deletes exactly once, instead of unconditionally:
+  ```java
+  deleted.removeIf(d -> matchedDeletedPaths.contains(d.getOldPath()));
+  matchedDeletedPaths = null;
+  ```
+
+### `SimilarityRenameDetector`
+
+- Constructor takes the shared `matchedSrcsPaths` set.
+- In `compute()`, the first content match of a source is a `RENAME`, the rest are `COPY`:
+  ```java
+  ChangeType type;
+  if (matchedSrcsPaths.add(s.getOldPath())) {
+    type = ChangeType.RENAME;
+  } else {
+    type = ChangeType.COPY;
+  }
+  ```
+
+`DiffEntry`, `ContentSource` and `SimilarityIndex` are copied unchanged; they are only present
+so the two patched classes have their package-private collaborators reachable in our package.
+
+## Re-syncing with a newer JGit
+
+When bumping the JGit dependency, re-copy the five upstream classes, then re-apply the two
+edits above (the `matchedDeletedPaths` field/plumbing in `RenameDetector` and the
+`matchedSrcsPaths` RENAME-vs-COPY branch in `SimilarityRenameDetector`). The copy-vs-rename
+cases in `FilteredRenameDetectorTest` / `FilteredRenameDetectorIT` guard the behaviour.

--- a/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
@@ -172,8 +172,9 @@ public class BlameGenerator {
   private List<RevCommit> resolveParents(GraphNode commitCandidate) throws IOException {
     // The path-scoped walk skips ancestors (and simplifies merges) that don't touch the blamed subfolder, so they
     // are never enqueued and diffed. It needs a real commit, so the working-dir node falls back to raw parents.
-    if (pathScopedWalk != null && commitCandidate.getCommit() != null) {
-      return pathScopedWalk.simplifiedParents(commitCandidate.getCommit());
+    RevCommit commit = commitCandidate.getCommit();
+    if (pathScopedWalk != null && commit != null) {
+      return pathScopedWalk.simplifiedParents(commit, commitCandidate.getAllPaths());
     }
 
     List<RevCommit> parentCommits = new ArrayList<>(commitCandidate.getParentCount());

--- a/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
@@ -55,12 +55,25 @@ public class BlameGenerator {
   private final RevWalk revPool;
   private final BiConsumer<Integer, String> progressCallBack;
 
-  public BlameGenerator(Repository repository, FileBlamer fileBlamer, GraphNodeFactory graphNodeFactory, @Nullable BiConsumer<Integer, String> progressCallBack) {
+  /**
+   * The deepest folder shared by every blamed file, or null when the blame is not scoped to a common subfolder (or
+   * the path-scoped walk optimization is disabled). When set, commits that don't touch this folder are skipped by
+   * the walk instead of being visited one by one - see {@link PathScopedWalk}.
+   */
+  @Nullable
+  private final String pathScopeFolder;
+
+  @Nullable
+  private PathScopedWalk pathScopedWalk;
+
+  public BlameGenerator(Repository repository, FileBlamer fileBlamer, GraphNodeFactory graphNodeFactory,
+    @Nullable BiConsumer<Integer, String> progressCallBack, @Nullable String pathScopeFolder) {
     this.repository = repository;
     this.fileBlamer = fileBlamer;
     this.graphNodeFactory = graphNodeFactory;
     this.revPool = new RevWalk(repository);
     this.progressCallBack = progressCallBack;
+    this.pathScopeFolder = pathScopeFolder;
   }
 
   private void prepareStartCommit(@CheckForNull ObjectId startCommit) throws IOException, NoHeadException {
@@ -76,6 +89,9 @@ public class BlameGenerator {
     }
 
     if (!graphNode.getAllFiles().isEmpty()) {
+      if (pathScopeFolder != null) {
+        pathScopedWalk = new PathScopedWalk(revPool, pathScopeFolder);
+      }
       fileBlamer.initialize(revPool.getObjectReader(), graphNode);
       push(graphNode);
     }
@@ -134,13 +150,7 @@ public class BlameGenerator {
   }
 
   private void process(GraphNode commitCandidate) throws IOException {
-    List<RevCommit> parentCommits = new ArrayList<>(commitCandidate.getParentCount());
-
-    for (int i = 0; i < commitCandidate.getParentCount(); i++) {
-      RevCommit parentCommit = commitCandidate.getParentCommit(i);
-      revPool.parseHeaders(parentCommit);
-      parentCommits.add(parentCommit);
-    }
+    List<RevCommit> parentCommits = resolveParents(commitCandidate);
 
     List<GraphNode> parentStatefulCommits;
     if (parentCommits.size() > 1) {
@@ -157,6 +167,22 @@ public class BlameGenerator {
 
     //Only process the result at the end, when all the regions have been assigned to each parent
     fileBlamer.saveBlameDataForFilesInCommit(commitCandidate);
+  }
+
+  private List<RevCommit> resolveParents(GraphNode commitCandidate) throws IOException {
+    // The path-scoped walk skips ancestors (and simplifies merges) that don't touch the blamed subfolder, so they
+    // are never enqueued and diffed. It needs a real commit, so the working-dir node falls back to raw parents.
+    if (pathScopedWalk != null && commitCandidate.getCommit() != null) {
+      return pathScopedWalk.simplifiedParents(commitCandidate.getCommit());
+    }
+
+    List<RevCommit> parentCommits = new ArrayList<>(commitCandidate.getParentCount());
+    for (int i = 0; i < commitCandidate.getParentCount(); i++) {
+      RevCommit parentCommit = commitCandidate.getParentCommit(i);
+      revPool.parseHeaders(parentCommit);
+      parentCommits.add(parentCommit);
+    }
+    return parentCommits;
   }
 
   private void close() {

--- a/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
@@ -135,7 +135,7 @@ public class FileBlamer {
 
   public List<GraphNode> blameParents(List<RevCommit> parentCommits, GraphNode child) throws IOException {
     // the working directory should always have a single parent
-    requireNonNull(child.getCommit());
+    RevCommit childCommit = requireNonNull(child.getCommit());
 
     List<GraphNode> parentStatefulCommits = new ArrayList<>(parentCommits.size());
     for (RevCommit parentCommit : parentCommits) {
@@ -144,31 +144,11 @@ public class FileBlamer {
 
     // diff files will include added,modified,rename,copy. It will not include unmodified files.
     List<List<DiffFile>> fileTreeDiffs = fileTreeComparator.supportsCheapDiff()
-      ? computeMergeDiffsWithScopedFallback(parentCommits, child)
-      : computeMergeDiffs(parentCommits, child);
+      ? computeMergeDiffsWithScopedFallback(parentCommits, child, childCommit)
+      : computeMergeDiffs(parentCommits, childCommit, child.getAllPaths());
 
-    // Detect unmodified files (same path)
-    for (int i = 0; i < parentCommits.size(); i++) {
-      Set<String> diffNewPaths = fileTreeDiffs.get(i).stream().map(DiffFile::getNewPath).collect(Collectors.toSet());
-      for (FileCandidate f : child.getAllFiles()) {
-        if (!diffNewPaths.contains(f.getPath())) {
-          // if file wasn't modified, it means it is unmodified. Move it to the parent.
-          moveFileToParent(parentStatefulCommits.get(i), f, f.getPath());
-        }
-      }
-    }
-
-    // Detect unmodified files with RENAME or COPY. They have the exact same BLOB but different paths
-    for (int i = 0; i < parentCommits.size(); i++) {
-      for (DiffFile diffFile : fileTreeDiffs.get(i)) {
-        Collection<FileCandidate> fileCandidates = child.getFilesByPath(diffFile.getNewPath());
-        for (FileCandidate f : fileCandidates) {
-          if (f.getBlob().equals(diffFile.getOldObjectId())) {
-            moveFileToParent(parentStatefulCommits.get(i), f, diffFile.getOldPath());
-          }
-        }
-      }
-    }
+    moveUnmodifiedSamePathFilesToParents(child, fileTreeDiffs, parentStatefulCommits);
+    moveUnmodifiedRenamedFilesToParents(child, fileTreeDiffs, parentStatefulCommits);
 
     // try to match regions with parents, using the file tree diffs that we already computed
     for (int i = 0; i < parentStatefulCommits.size(); i++) {
@@ -177,10 +157,35 @@ public class FileBlamer {
     return parentStatefulCommits;
   }
 
-  private List<List<DiffFile>> computeMergeDiffs(List<RevCommit> parentCommits, GraphNode child) throws IOException {
+  private static void moveUnmodifiedSamePathFilesToParents(GraphNode child, List<List<DiffFile>> fileTreeDiffs, List<GraphNode> parentStatefulCommits) {
+    for (int i = 0; i < parentStatefulCommits.size(); i++) {
+      Set<String> diffNewPaths = fileTreeDiffs.get(i).stream().map(DiffFile::getNewPath).collect(Collectors.toSet());
+      for (FileCandidate f : child.getAllFiles()) {
+        if (!diffNewPaths.contains(f.getPath())) {
+          // if file wasn't modified, it means it is unmodified. Move it to the parent.
+          moveFileToParent(parentStatefulCommits.get(i), f, f.getPath());
+        }
+      }
+    }
+  }
+
+  private static void moveUnmodifiedRenamedFilesToParents(GraphNode child, List<List<DiffFile>> fileTreeDiffs, List<GraphNode> parentStatefulCommits) {
+    // Unmodified files with RENAME or COPY have the exact same BLOB but a different path.
+    for (int i = 0; i < parentStatefulCommits.size(); i++) {
+      for (DiffFile diffFile : fileTreeDiffs.get(i)) {
+        for (FileCandidate f : child.getFilesByPath(diffFile.getNewPath())) {
+          if (f.getBlob().equals(diffFile.getOldObjectId())) {
+            moveFileToParent(parentStatefulCommits.get(i), f, diffFile.getOldPath());
+          }
+        }
+      }
+    }
+  }
+
+  private List<List<DiffFile>> computeMergeDiffs(List<RevCommit> parentCommits, RevCommit childCommit, Set<String> blamedPaths) throws IOException {
     List<List<DiffFile>> fileTreeDiffs = new ArrayList<>(parentCommits.size());
     for (RevCommit parentCommit : parentCommits) {
-      fileTreeDiffs.add(fileTreeComparator.findMovedFiles(parentCommit, child.getCommit(), child.getAllPaths()));
+      fileTreeDiffs.add(fileTreeComparator.findMovedFiles(parentCommit, childCommit, blamedPaths));
     }
     return fileTreeDiffs;
   }
@@ -194,14 +199,14 @@ public class FileBlamer {
    * blame. The full fallback still runs for a parent whose added files are not carried by any other parent (a real
    * rename or add), so the result is identical to {@link #computeMergeDiffs}.
    */
-  private List<List<DiffFile>> computeMergeDiffsWithScopedFallback(List<RevCommit> parentCommits, GraphNode child) throws IOException {
+  private List<List<DiffFile>> computeMergeDiffsWithScopedFallback(List<RevCommit> parentCommits, GraphNode child, RevCommit childCommit) throws IOException {
     int n = parentCommits.size();
     Set<String> blamedPaths = child.getAllPaths();
 
     List<FileTreeComparator.CheapDiff> cheapDiffs = new ArrayList<>(n);
     List<Set<String>> changedPathsPerParent = new ArrayList<>(n);
     for (RevCommit parentCommit : parentCommits) {
-      FileTreeComparator.CheapDiff cheap = fileTreeComparator.cheapDiff(parentCommit, child.getCommit(), blamedPaths);
+      FileTreeComparator.CheapDiff cheap = fileTreeComparator.cheapDiff(parentCommit, childCommit, blamedPaths);
       cheapDiffs.add(cheap);
       Set<String> changed = new HashSet<>(cheap.addedPaths());
       cheap.modified().forEach(diffFile -> changed.add(diffFile.getNewPath()));
@@ -216,7 +221,7 @@ public class FileBlamer {
       } else if (allAddedPathsCarriedByAnotherParent(cheap.addedPaths(), i, changedPathsPerParent)) {
         fileTreeDiffs.add(withSyntheticAddedFiles(cheap));
       } else {
-        fileTreeDiffs.add(fileTreeComparator.fullDiff(parentCommits.get(i), child.getCommit(), blamedPaths));
+        fileTreeDiffs.add(fileTreeComparator.fullDiff(parentCommits.get(i), childCommit, blamedPaths));
       }
     }
     return fileTreeDiffs;

--- a/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
@@ -137,17 +137,15 @@ public class FileBlamer {
     // the working directory should always have a single parent
     requireNonNull(child.getCommit());
 
-    List<List<DiffFile>> fileTreeDiffs = new ArrayList<>(parentCommits.size());
     List<GraphNode> parentStatefulCommits = new ArrayList<>(parentCommits.size());
-
-    // first compute differences compared to each parent
     for (RevCommit parentCommit : parentCommits) {
-      GraphNode parentStatefulCommit = new CommitGraphNode(parentCommit, child.getAllFiles().size());
-      parentStatefulCommits.add(parentStatefulCommit);
-
-      // diff files will include added,modified,rename,copy. It will not include unmodified files.
-      fileTreeDiffs.add(fileTreeComparator.findMovedFiles(parentCommit, child.getCommit(), child.getAllPaths()));
+      parentStatefulCommits.add(new CommitGraphNode(parentCommit, child.getAllFiles().size()));
     }
+
+    // diff files will include added,modified,rename,copy. It will not include unmodified files.
+    List<List<DiffFile>> fileTreeDiffs = fileTreeComparator.supportsCheapDiff()
+      ? computeMergeDiffsWithScopedFallback(parentCommits, child)
+      : computeMergeDiffs(parentCommits, child);
 
     // Detect unmodified files (same path)
     for (int i = 0; i < parentCommits.size(); i++) {
@@ -177,6 +175,81 @@ public class FileBlamer {
       blameWithFileDiffs(parentStatefulCommits.get(i), child, fileTreeDiffs.get(i));
     }
     return parentStatefulCommits;
+  }
+
+  private List<List<DiffFile>> computeMergeDiffs(List<RevCommit> parentCommits, GraphNode child) throws IOException {
+    List<List<DiffFile>> fileTreeDiffs = new ArrayList<>(parentCommits.size());
+    for (RevCommit parentCommit : parentCommits) {
+      fileTreeDiffs.add(fileTreeComparator.findMovedFiles(parentCommit, child.getCommit(), child.getAllPaths()));
+    }
+    return fileTreeDiffs;
+  }
+
+  /**
+   * Computes each parent's diff for a merge while running the expensive full-repository rename fallback only when it
+   * can actually affect the blame. At a merge, a file that looks added relative to one parent is very often carried
+   * unchanged by another parent, which claims all of its regions before any diff-splitting happens (see the
+   * unmodified-file handling in {@link #blameParents}). In that case resolving where the "added" file came from in
+   * this parent is wasted work, so we replace it with a synthetic added-file entry, which drives the exact same
+   * blame. The full fallback still runs for a parent whose added files are not carried by any other parent (a real
+   * rename or add), so the result is identical to {@link #computeMergeDiffs}.
+   */
+  private List<List<DiffFile>> computeMergeDiffsWithScopedFallback(List<RevCommit> parentCommits, GraphNode child) throws IOException {
+    int n = parentCommits.size();
+    Set<String> blamedPaths = child.getAllPaths();
+
+    List<FileTreeComparator.CheapDiff> cheapDiffs = new ArrayList<>(n);
+    List<Set<String>> changedPathsPerParent = new ArrayList<>(n);
+    for (RevCommit parentCommit : parentCommits) {
+      FileTreeComparator.CheapDiff cheap = fileTreeComparator.cheapDiff(parentCommit, child.getCommit(), blamedPaths);
+      cheapDiffs.add(cheap);
+      Set<String> changed = new HashSet<>(cheap.addedPaths());
+      cheap.modified().forEach(diffFile -> changed.add(diffFile.getNewPath()));
+      changedPathsPerParent.add(changed);
+    }
+
+    List<List<DiffFile>> fileTreeDiffs = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      FileTreeComparator.CheapDiff cheap = cheapDiffs.get(i);
+      if (!cheap.hasAddedPaths()) {
+        fileTreeDiffs.add(new ArrayList<>(cheap.modified()));
+      } else if (allAddedPathsCarriedByAnotherParent(cheap.addedPaths(), i, changedPathsPerParent)) {
+        fileTreeDiffs.add(withSyntheticAddedFiles(cheap));
+      } else {
+        fileTreeDiffs.add(fileTreeComparator.fullDiff(parentCommits.get(i), child.getCommit(), blamedPaths));
+      }
+    }
+    return fileTreeDiffs;
+  }
+
+  /**
+   * @return true if every {@code addedPath} is unchanged (present with the same blob at the same path) in at least
+   *         one parent other than {@code parentIndex}, which will therefore claim its regions regardless of what
+   *         this parent's diff says.
+   */
+  private static boolean allAddedPathsCarriedByAnotherParent(Set<String> addedPaths, int parentIndex, List<Set<String>> changedPathsPerParent) {
+    for (String addedPath : addedPaths) {
+      boolean carried = false;
+      for (int j = 0; j < changedPathsPerParent.size(); j++) {
+        if (j != parentIndex && !changedPathsPerParent.get(j).contains(addedPath)) {
+          carried = true;
+          break;
+        }
+      }
+      if (!carried) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static List<DiffFile> withSyntheticAddedFiles(FileTreeComparator.CheapDiff cheap) {
+    List<DiffFile> diffFiles = new ArrayList<>(cheap.modified());
+    for (String addedPath : cheap.addedPaths()) {
+      // Mirror what the full diff produces for an added file with no rename source: a null old path.
+      diffFiles.add(new DiffFile(addedPath, addedPath, ObjectId.zeroId()));
+    }
+    return diffFiles;
   }
 
   public void close() {

--- a/src/main/java/org/sonar/scm/git/blame/FileTreeComparator.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileTreeComparator.java
@@ -22,7 +22,9 @@ package org.sonar.scm.git.blame;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -55,14 +57,24 @@ public class FileTreeComparator {
    */
   private final boolean useFilteredDiff;
 
+  /**
+   * Whether path-scoping optimizations are enabled. When true, at a merge the expensive full-repository diff is run
+   * for a parent only if a file added relative to it isn't already carried, unchanged, by another parent - see
+   * {@link #supportsCheapDiff()} and {@link FileBlamer}. Always on in production; tests turn it off to compare
+   * against the unscoped result.
+   */
+  private final boolean pathScoping;
+
   private TreeWalk treeWalk;
   private TreeFilter filesAndAnyDiffFilter = null;
   private Set<String> filterFilePaths = null;
 
-  public FileTreeComparator(Repository repository, FilteredRenameDetector filteredRenameDetector, @Nullable Set<String> filePathsToBlame) {
+  public FileTreeComparator(Repository repository, FilteredRenameDetector filteredRenameDetector, @Nullable Set<String> filePathsToBlame,
+    boolean pathScoping) {
     this.repository = repository;
     this.filteredRenameDetector = filteredRenameDetector;
     this.useFilteredDiff = isUnderCommonSubfolder(filePathsToBlame);
+    this.pathScoping = pathScoping;
   }
 
   /**
@@ -70,10 +82,20 @@ public class FileTreeComparator {
    *         than the repository root itself.
    */
   static boolean isUnderCommonSubfolder(@Nullable Set<String> filePaths) {
+    return commonSubfolder(filePaths).isPresent();
+  }
+
+  /**
+   * @return the deepest directory that every path in {@code filePaths} lives under, or empty if they only share the
+   *         repository root. The returned path has no trailing slash (e.g. {@code "net/ethtool"}).
+   */
+  static Optional<String> commonSubfolder(@Nullable Set<String> filePaths) {
     if (filePaths == null || filePaths.isEmpty()) {
-      return false;
+      return Optional.empty();
     }
-    return longestCommonPrefix(filePaths).lastIndexOf('/') >= 0;
+    String prefix = longestCommonPrefix(filePaths);
+    int lastSlash = prefix.lastIndexOf('/');
+    return lastSlash < 0 ? Optional.empty() : Optional.of(prefix.substring(0, lastSlash));
   }
 
   private static String longestCommonPrefix(Set<String> paths) {
@@ -139,6 +161,15 @@ public class FileTreeComparator {
       }
     }
 
+    return fullDiff(parent, child, filePathsToInclude);
+  }
+
+  /**
+   * The full-repository diff plus rename detection: needed to find where a blamed file that appears added came from,
+   * since its rename source can be anywhere in the tree (even outside the blamed subfolder). This is the expensive
+   * path - on a large repository it scans the entire parent-to-child diff.
+   */
+  List<DiffFile> fullDiff(RevCommit parent, RevCommit child, Set<String> filePathsToInclude) throws IOException {
     // to detect renames, we need to collect all modified files in the repo
     Collection<DiffEntry> diffEntries = getDiffEntries(parent, child);
     diffEntries = detectRenames(filePathsToInclude, diffEntries);
@@ -153,16 +184,7 @@ public class FileTreeComparator {
 
   @CheckForNull
   private List<DiffFile> findMovedFilesWithPathFilter(RevCommit parent, RevCommit child, Set<String> filePaths) throws IOException {
-    if (!filePaths.equals(filterFilePaths)) {
-      // this is expensive to compute
-      TreeFilter pathFilterGroup = PathFilterGroup.createFromStrings(filePaths);
-      filesAndAnyDiffFilter = AndTreeFilter.create(pathFilterGroup, TreeFilter.ANY_DIFF);
-      filterFilePaths = filePaths;
-    }
-
-    // With this filter, we'll traverse both trees, only visiting the files that are being blamed and that are different between both trees.
-    treeWalk.setFilter(filesAndAnyDiffFilter);
-    treeWalk.reset(parent.getTree(), child.getTree());
+    startPathFilteredWalk(parent, child, filePaths);
 
     List<DiffFile> movedFiles = new ArrayList<>(filePaths.size());
 
@@ -177,6 +199,63 @@ public class FileTreeComparator {
       }
     }
     return movedFiles;
+  }
+
+  private void startPathFilteredWalk(RevCommit parent, RevCommit child, Set<String> filePaths) throws IOException {
+    if (!filePaths.equals(filterFilePaths)) {
+      // this is expensive to compute
+      TreeFilter pathFilterGroup = PathFilterGroup.createFromStrings(filePaths);
+      filesAndAnyDiffFilter = AndTreeFilter.create(pathFilterGroup, TreeFilter.ANY_DIFF);
+      filterFilePaths = filePaths;
+    }
+    // With this filter, we'll traverse both trees, only visiting the files that are being blamed and that are different between both trees.
+    treeWalk.setFilter(filesAndAnyDiffFilter);
+    treeWalk.reset(parent.getTree(), child.getTree());
+  }
+
+  /**
+   * @return true if the path-filtered diff can be used, i.e. all blamed files share a common subfolder so a filter
+   *         on them is worth building. Only then can {@link #cheapDiff} split blamed files into modified vs added
+   *         without the full-repository diff.
+   */
+  boolean supportsCheapDiff() {
+    return useFilteredDiff && pathScoping;
+  }
+
+  /**
+   * A path-filtered diff of the blamed files between {@code parent} and {@code child} that never falls back to the
+   * full-repository diff: blamed files present in the parent (possibly modified) are resolved to their parent blob,
+   * while blamed files absent from the parent are only reported as added paths - resolving where an added file came
+   * from (its rename source) still needs {@link #fullDiff}.
+   */
+  CheapDiff cheapDiff(RevCommit parent, RevCommit child, Set<String> filePaths) throws IOException {
+    startPathFilteredWalk(parent, child, filePaths);
+
+    List<DiffFile> modified = new ArrayList<>();
+    Set<String> addedPaths = new HashSet<>();
+    while (treeWalk.next()) {
+      String path = treeWalk.getPathString();
+      if (filePaths.contains(path)) {
+        treeWalk.getObjectId(idBuf, 0);
+        if (isAddedOrNotFile()) {
+          addedPaths.add(path);
+        } else {
+          modified.add(new DiffFile(path, path, idBuf.toObjectId()));
+        }
+      }
+    }
+    return new CheapDiff(modified, addedPaths);
+  }
+
+  /**
+   * Outcome of {@link #cheapDiff}: the blamed files that changed between the two commits, split into files still
+   * present in the parent ({@link #modified}, resolved to their parent blob) and files absent from the parent
+   * ({@link #addedPaths}, whose rename source, if any, is not yet known). Blamed files in neither set are unchanged.
+   */
+  record CheapDiff(List<DiffFile> modified, Set<String> addedPaths) {
+    boolean hasAddedPaths() {
+      return !addedPaths.isEmpty();
+    }
   }
 
   private boolean isAddedOrNotFile() {

--- a/src/main/java/org/sonar/scm/git/blame/FileTreeComparator.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileTreeComparator.java
@@ -42,23 +42,58 @@ import static org.eclipse.jgit.lib.FileMode.TYPE_FILE;
 import static org.eclipse.jgit.lib.FileMode.TYPE_MASK;
 
 public class FileTreeComparator {
-  /**
-   * If the number of files we are interested in is smaller than this threshold, create a filter to only look
-   * for these files. Creating the filter is expensive and is not worth it for large number of files.
-   */
-  private static final int THRESHOLD_FILTER_FILES = 100;
-
   private final MutableObjectId idBuf = new MutableObjectId();
   private final Repository repository;
   private final FilteredRenameDetector filteredRenameDetector;
+
+  /**
+   * Whether the files being blamed all live under some common subfolder of the repository, decided once from the
+   * original request rather than re-derived on every commit. When true, a path-scoped tree diff is worth its own
+   * setup cost: any other subfolder untouched by a given commit is skipped without even being looked at. When the
+   * files being blamed are spread across the repository root (or it's a full-repository blame), most subfolders
+   * are relevant anyway, so scoping the diff has no upside and only adds overhead.
+   */
+  private final boolean useFilteredDiff;
 
   private TreeWalk treeWalk;
   private TreeFilter filesAndAnyDiffFilter = null;
   private Set<String> filterFilePaths = null;
 
-  public FileTreeComparator(Repository repository, FilteredRenameDetector filteredRenameDetector) {
+  public FileTreeComparator(Repository repository, FilteredRenameDetector filteredRenameDetector, @Nullable Set<String> filePathsToBlame) {
     this.repository = repository;
     this.filteredRenameDetector = filteredRenameDetector;
+    this.useFilteredDiff = isUnderCommonSubfolder(filePathsToBlame);
+  }
+
+  /**
+   * @return true if every path in {@code filePaths} lives under some shared directory of the repository, other
+   *         than the repository root itself.
+   */
+  static boolean isUnderCommonSubfolder(@Nullable Set<String> filePaths) {
+    if (filePaths == null || filePaths.isEmpty()) {
+      return false;
+    }
+    return longestCommonPrefix(filePaths).lastIndexOf('/') >= 0;
+  }
+
+  private static String longestCommonPrefix(Set<String> paths) {
+    String prefix = null;
+    for (String path : paths) {
+      if (prefix == null) {
+        prefix = path;
+        continue;
+      }
+      int len = Math.min(prefix.length(), path.length());
+      int i = 0;
+      while (i < len && prefix.charAt(i) == path.charAt(i)) {
+        i++;
+      }
+      prefix = prefix.substring(0, i);
+      if (prefix.isEmpty()) {
+        return prefix;
+      }
+    }
+    return prefix;
   }
 
   public void initialize(ObjectReader objectReader) {
@@ -97,8 +132,8 @@ public class FileTreeComparator {
     if (child == null) {
       return computeForWorkingDir(parent, filePathsToInclude);
     }
-    if (filePathsToInclude.size() < THRESHOLD_FILTER_FILES) {
-      List<DiffFile> modifiedFiles = findMovedFilesForSmallSet(parent, child, filePathsToInclude);
+    if (useFilteredDiff) {
+      List<DiffFile> modifiedFiles = findMovedFilesWithPathFilter(parent, child, filePathsToInclude);
       if (modifiedFiles != null) {
         return modifiedFiles;
       }
@@ -117,7 +152,7 @@ public class FileTreeComparator {
   }
 
   @CheckForNull
-  private List<DiffFile> findMovedFilesForSmallSet(RevCommit parent, RevCommit child, Set<String> filePaths) throws IOException {
+  private List<DiffFile> findMovedFilesWithPathFilter(RevCommit parent, RevCommit child, Set<String> filePaths) throws IOException {
     if (!filePaths.equals(filterFilePaths)) {
       // this is expensive to compute
       TreeFilter pathFilterGroup = PathFilterGroup.createFromStrings(filePaths);

--- a/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
+++ b/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
@@ -162,11 +162,6 @@ class PathScopedWalk {
    * {@code commit}, so the blame regions can be moved onto it directly.
    */
   RevCommit collapse(RevCommit commit) throws IOException {
-    RevCommit cached = collapseCache.get(commit.getId());
-    if (cached != null) {
-      return cached;
-    }
-
     List<ObjectId> skipped = new ArrayList<>();
     RevCommit current = commit;
     boolean canSkip = true;

--- a/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
+++ b/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
@@ -1,0 +1,158 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
+
+/**
+ * Speeds up blaming files that all live under a common subfolder by letting the blame walk skip over the (often
+ * large) majority of commits that never touch that subfolder.
+ *
+ * <p>The blame algorithm walks the whole commit ancestry of the start commit, carrying the regions still to be
+ * blamed backwards commit by commit. On a big repository where only a small subfolder is blamed (a monorepo where
+ * one module is analyzed, say), most commits touch other parts of the tree and leave the blamed subfolder
+ * untouched. Those commits contribute nothing to the blame - every region simply moves unchanged to their parent -
+ * yet each one is still visited, diffed and enqueued.
+ *
+ * <p>{@link #collapse(RevCommit)} detects such commits cheaply, by comparing the object id of the subfolder's tree
+ * between a commit and its parent (a commit that didn't touch the subfolder has the exact same subfolder tree id as
+ * its parent). It then follows the chain of single-parent ancestors that left the subfolder untouched and returns
+ * the first ancestor that changed it (or a merge or root commit). Skipping a commit is safe precisely because its
+ * subfolder tree is identical to the returned ancestor's, so moving the regions across the skipped span is a no-op.
+ *
+ * <p>The subfolder tree ids are read on demand and cached, so each ancestor is inspected at most once - there is no
+ * separate up-front history pass. Renames are handled naturally: a commit that renames a file within (or into) the
+ * subfolder changes the subfolder's tree, so it is kept as a boundary and diffed as usual.
+ *
+ * <p>Merges are NOT simplified - all their parents are kept and diffed as usual, so the result stays identical to
+ * the unscoped walk. Skipping a merge parent based on the subfolder tree is tempting but not exact: blame works at
+ * line granularity, and a line can match a parent whose overall subfolder tree differs from the merge, so the
+ * unscoped walk can follow that line into a parent a folder-tree comparison would have pruned. That means this
+ * optimization only reduces work between merges; on a history whose mainline is a near-unbroken series of merges
+ * (the Linux kernel, say) there is little to skip.
+ */
+class PathScopedWalk {
+  private final RevWalk revPool;
+  private final ObjectReader objectReader;
+  private final String folder;
+  private final Map<ObjectId, ObjectId> folderTreeIdCache = new HashMap<>();
+  private final Map<ObjectId, RevCommit> collapseCache = new HashMap<>();
+
+  /**
+   * @param revPool the walk's revision pool, reused to parse the ancestors visited while collapsing
+   * @param folder the common subfolder shared by every blamed file (no trailing slash)
+   */
+  PathScopedWalk(RevWalk revPool, String folder) {
+    this.revPool = revPool;
+    this.objectReader = revPool.getObjectReader();
+    this.folder = folder;
+  }
+
+  /**
+   * The parents the blame walk should actually descend into for {@code commit}. A single-parent commit yields its
+   * collapsed parent, skipping the chain of ancestors that don't touch the blamed subfolder. A merge yields all its
+   * parents unchanged (see the class javadoc for why merges can't be simplified exactly).
+   */
+  List<RevCommit> simplifiedParents(RevCommit commit) throws IOException {
+    int parentCount = commit.getParentCount();
+    if (parentCount == 1) {
+      return List.of(collapse(parseParent(commit, 0)));
+    }
+
+    // Merges keep all their parents and are diffed as usual: skipping a merge parent (even one whose subfolder tree
+    // matches the merge) is not exact, because blame works at line granularity and a line can match a parent the
+    // merge's subfolder tree differs from - the unscoped walk follows those line-level matches into that parent.
+    List<RevCommit> parents = new ArrayList<>(parentCount);
+    for (int i = 0; i < parentCount; i++) {
+      parents.add(parseParent(commit, i));
+    }
+    return parents;
+  }
+
+  private RevCommit parseParent(RevCommit commit, int i) throws IOException {
+    RevCommit parent = commit.getParent(i);
+    revPool.parseHeaders(parent);
+    return parent;
+  }
+
+  /**
+   * Follows single-parent ancestors that leave the blamed subfolder untouched and returns the first ancestor that
+   * changes it, or the first merge or root commit reached. The returned commit has the exact same subfolder tree as
+   * {@code commit}, so the blame regions can be moved onto it directly.
+   */
+  RevCommit collapse(RevCommit commit) throws IOException {
+    RevCommit cached = collapseCache.get(commit.getId());
+    if (cached != null) {
+      return cached;
+    }
+
+    List<ObjectId> skipped = new ArrayList<>();
+    RevCommit current = commit;
+    while (current.getParentCount() == 1) {
+      RevCommit alreadyResolved = collapseCache.get(current.getId());
+      if (alreadyResolved != null) {
+        current = alreadyResolved;
+        break;
+      }
+      RevCommit parent = current.getParent(0);
+      revPool.parseHeaders(parent);
+      ObjectId currentFolder = folderTreeId(current);
+      // Stop (don't skip) when the subfolder doesn't exist at current: the blamed files lived elsewhere back then
+      // (a directory rename/reorg), and only the normal walk follows content across that boundary. Also stop when
+      // current changed the subfolder relative to its parent - it must be diffed.
+      if (currentFolder.equals(ObjectId.zeroId()) || !currentFolder.equals(folderTreeId(parent))) {
+        break;
+      }
+      skipped.add(current.getId());
+      current = parent;
+    }
+
+    for (ObjectId id : skipped) {
+      collapseCache.put(id, current);
+    }
+    return current;
+  }
+
+  /**
+   * @return the object id of the subfolder's tree in the given commit, or {@link ObjectId#zeroId()} if the
+   *         subfolder doesn't exist there.
+   */
+  private ObjectId folderTreeId(RevCommit commit) throws IOException {
+    ObjectId cached = folderTreeIdCache.get(commit.getId());
+    if (cached != null) {
+      return cached;
+    }
+    ObjectId id;
+    try (TreeWalk treeWalk = TreeWalk.forPath(objectReader, folder, commit.getTree())) {
+      id = treeWalk != null ? treeWalk.getObjectId(0) : ObjectId.zeroId();
+    }
+    folderTreeIdCache.put(commit.getId(), id);
+    return id;
+  }
+}

--- a/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
+++ b/src/main/java/org/sonar/scm/git/blame/PathScopedWalk.java
@@ -24,11 +24,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 
 /**
  * Speeds up blaming files that all live under a common subfolder by letting the blame walk skip over the (often
@@ -47,8 +51,16 @@ import org.eclipse.jgit.treewalk.TreeWalk;
  * subfolder tree is identical to the returned ancestor's, so moving the regions across the skipped span is a no-op.
  *
  * <p>The subfolder tree ids are read on demand and cached, so each ancestor is inspected at most once - there is no
- * separate up-front history pass. Renames are handled naturally: a commit that renames a file within (or into) the
- * subfolder changes the subfolder's tree, so it is kept as a boundary and diffed as usual.
+ * separate up-front history pass. Renames <em>within</em> the subfolder are handled naturally: they change the
+ * subfolder's tree, so the commit is kept as a boundary and diffed as usual.
+ *
+ * <p>Renames <em>into</em> the subfolder from an outside path need more care. Skipping is only safe for content that
+ * stayed inside the subfolder for the whole skipped span; a file renamed in from elsewhere carries content whose
+ * source lived outside the subfolder and may have been modified by a commit we would otherwise skip. Two guards keep
+ * the result exact: {@link #simplifiedParents(RevCommit, Set)} does not collapse the parent of a commit that adds a
+ * blamed path to the subfolder (its rename source, resolved by the diff, could be an outside path touched in the
+ * skipped span), and it stops collapsing altogether once any blamed file has moved outside the subfolder, letting the
+ * normal walk follow that content wherever it goes.
  *
  * <p>Merges are NOT simplified - all their parents are kept and diffed as usual, so the result stays identical to
  * the unscoped walk. Skipping a merge parent based on the subfolder tree is tempting but not exact: blame works at
@@ -78,21 +90,64 @@ class PathScopedWalk {
    * The parents the blame walk should actually descend into for {@code commit}. A single-parent commit yields its
    * collapsed parent, skipping the chain of ancestors that don't touch the blamed subfolder. A merge yields all its
    * parents unchanged (see the class javadoc for why merges can't be simplified exactly).
+   *
+   * @param blamedPaths the current paths of the files still being blamed at {@code commit}
    */
-  List<RevCommit> simplifiedParents(RevCommit commit) throws IOException {
+  List<RevCommit> simplifiedParents(RevCommit commit, Set<String> blamedPaths) throws IOException {
     int parentCount = commit.getParentCount();
-    if (parentCount == 1) {
-      return List.of(collapse(parseParent(commit, 0)));
+    if (parentCount != 1) {
+      // Merges keep all their parents and are diffed as usual: skipping a merge parent (even one whose subfolder tree
+      // matches the merge) is not exact, because blame works at line granularity and a line can match a parent the
+      // merge's subfolder tree differs from - the unscoped walk follows those line-level matches into that parent.
+      List<RevCommit> parents = new ArrayList<>(parentCount);
+      for (int i = 0; i < parentCount; i++) {
+        parents.add(parseParent(commit, i));
+      }
+      return parents;
     }
 
-    // Merges keep all their parents and are diffed as usual: skipping a merge parent (even one whose subfolder tree
-    // matches the merge) is not exact, because blame works at line granularity and a line can match a parent the
-    // merge's subfolder tree differs from - the unscoped walk follows those line-level matches into that parent.
-    List<RevCommit> parents = new ArrayList<>(parentCount);
-    for (int i = 0; i < parentCount; i++) {
-      parents.add(parseParent(commit, i));
+    RevCommit parent = parseParent(commit, 0);
+    // A blamed file living outside the subfolder was renamed in from elsewhere and is now followed by its old path;
+    // the commits that touched it don't touch the subfolder, so collapsing would wrongly skip them. Fall back to the
+    // real parent so the normal walk follows that content.
+    if (!allUnderFolder(blamedPaths)) {
+      return List.of(parent);
     }
-    return parents;
+
+    RevCommit collapsed = collapse(parent);
+    // When collapse skipped commits, this commit is diffed against a further-back ancestor instead of its real
+    // parent. That is exact for content that stayed in the subfolder, but not for a file added to the subfolder here
+    // by a rename: its source can be an outside path modified in a skipped commit, which the ancestor no longer
+    // reflects. Diff such a commit against its real parent instead. When nothing was skipped there is no such gap.
+    if (collapsed != parent && addsBlamedPathToFolder(commit, parent)) {
+      return List.of(parent);
+    }
+    return List.of(collapsed);
+  }
+
+  private boolean allUnderFolder(Set<String> paths) {
+    String folderPrefix = folder + "/";
+    return paths.stream().allMatch(path -> path.startsWith(folderPrefix));
+  }
+
+  /**
+   * @return true if {@code commit} adds a file to the blamed subfolder relative to {@code parent}. A path-filtered
+   *         diff restricted to the subfolder, so it only visits the files that changed there.
+   */
+  private boolean addsBlamedPathToFolder(RevCommit commit, RevCommit parent) throws IOException {
+    try (TreeWalk treeWalk = new TreeWalk(objectReader)) {
+      treeWalk.addTree(parent.getTree());
+      treeWalk.addTree(commit.getTree());
+      treeWalk.setRecursive(true);
+      treeWalk.setFilter(AndTreeFilter.create(PathFilter.create(folder), TreeFilter.ANY_DIFF));
+      while (treeWalk.next()) {
+        // Absent in the parent (tree 0) but present in the commit (tree 1): a file added into the subfolder.
+        if (treeWalk.getRawMode(0) == 0) {
+          return true;
+        }
+      }
+      return false;
+    }
   }
 
   private RevCommit parseParent(RevCommit commit, int i) throws IOException {
@@ -114,29 +169,38 @@ class PathScopedWalk {
 
     List<ObjectId> skipped = new ArrayList<>();
     RevCommit current = commit;
-    while (current.getParentCount() == 1) {
+    boolean canSkip = true;
+    while (canSkip && current.getParentCount() == 1) {
       RevCommit alreadyResolved = collapseCache.get(current.getId());
       if (alreadyResolved != null) {
         current = alreadyResolved;
-        break;
+        canSkip = false;
+      } else if (canSkipCurrent(current)) {
+        skipped.add(current.getId());
+        current = current.getParent(0);
+      } else {
+        canSkip = false;
       }
-      RevCommit parent = current.getParent(0);
-      revPool.parseHeaders(parent);
-      ObjectId currentFolder = folderTreeId(current);
-      // Stop (don't skip) when the subfolder doesn't exist at current: the blamed files lived elsewhere back then
-      // (a directory rename/reorg), and only the normal walk follows content across that boundary. Also stop when
-      // current changed the subfolder relative to its parent - it must be diffed.
-      if (currentFolder.equals(ObjectId.zeroId()) || !currentFolder.equals(folderTreeId(parent))) {
-        break;
-      }
-      skipped.add(current.getId());
-      current = parent;
     }
 
     for (ObjectId id : skipped) {
       collapseCache.put(id, current);
     }
     return current;
+  }
+
+  /**
+   * @return true if {@code current} left the blamed subfolder untouched relative to its single parent, so the blame
+   *         regions can be moved straight onto that parent. Parses the parent's headers as a side effect.
+   */
+  private boolean canSkipCurrent(RevCommit current) throws IOException {
+    RevCommit parent = current.getParent(0);
+    revPool.parseHeaders(parent);
+    ObjectId currentFolder = folderTreeId(current);
+    // Don't skip when the subfolder doesn't exist at current: the blamed files lived elsewhere back then (a directory
+    // rename/reorg), and only the normal walk follows content across that boundary. Don't skip when current changed
+    // the subfolder relative to its parent either - it must be diffed.
+    return !currentFolder.equals(ObjectId.zeroId()) && currentFolder.equals(folderTreeId(parent));
   }
 
   /**

--- a/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
+++ b/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
@@ -46,6 +46,7 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
   private ObjectId startCommit = null;
   private Set<String> filePaths = null;
   private boolean multithreading = false;
+  private boolean pathScoping = true;
   private BiConsumer<Integer, String> progressCallBack;
   private UnaryOperator<String> fileContentProvider = null;
 
@@ -66,6 +67,17 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
    */
   public RepositoryBlameCommand setMultithreading(boolean multithreading) {
     this.multithreading = multithreading;
+    return this;
+  }
+
+  /**
+   * When all blamed files live under a common subfolder, the blame is scoped to that subfolder: the walk collapses
+   * chains of commits that don't touch it, and the expensive full-repository rename diff is skipped at a merge for
+   * any parent that doesn't need it. This produces the exact same blame, only faster, and is always on in
+   * production. Exposed only so tests can compare the scoped result against the unscoped one.
+   */
+  RepositoryBlameCommand setPathScoping(boolean pathScoping) {
+    this.pathScoping = pathScoping;
     return this;
   }
 
@@ -123,15 +135,17 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
     try {
       BlobReader blobReader = new BlobReader(repo, fileContentProvider);
       FilteredRenameDetector filteredRenameDetector = new FilteredRenameDetector(new RenameDetector(repo));
-      FileTreeComparator fileTreeComparator = new FileTreeComparator(repo, filteredRenameDetector, filePaths);
+      FileTreeComparator fileTreeComparator = new FileTreeComparator(repo, filteredRenameDetector, filePaths, pathScoping);
       FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, diffAlgorithm, textComparator, blobReader, blameResult, multithreading);
 
       if (filePaths != null && filePaths.isEmpty()) {
         return blameResult;
       }
 
+      String pathScopeFolder = pathScoping ? FileTreeComparator.commonSubfolder(filePaths).orElse(null) : null;
+
       GraphNodeFactory graphNodeFactory = new GraphNodeFactory(repo, filePaths);
-      BlameGenerator blameGenerator = new BlameGenerator(repo, fileBlamer, graphNodeFactory, progressCallBack);
+      BlameGenerator blameGenerator = new BlameGenerator(repo, fileBlamer, graphNodeFactory, progressCallBack, pathScopeFolder);
       blameGenerator.generateBlame(startCommit);
     } catch (IOException e) {
       throw new IllegalStateException("Failed to blame repository files", e);

--- a/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
+++ b/src/main/java/org/sonar/scm/git/blame/RepositoryBlameCommand.java
@@ -123,7 +123,7 @@ public class RepositoryBlameCommand extends GitCommand<BlameResult> {
     try {
       BlobReader blobReader = new BlobReader(repo, fileContentProvider);
       FilteredRenameDetector filteredRenameDetector = new FilteredRenameDetector(new RenameDetector(repo));
-      FileTreeComparator fileTreeComparator = new FileTreeComparator(repo, filteredRenameDetector);
+      FileTreeComparator fileTreeComparator = new FileTreeComparator(repo, filteredRenameDetector, filePaths);
       FileBlamer fileBlamer = new FileBlamer(fileTreeComparator, diffAlgorithm, textComparator, blobReader, blameResult, multithreading);
 
       if (filePaths != null && filePaths.isEmpty()) {

--- a/src/test/java/org/sonar/scm/git/blame/FileTreeComparatorTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FileTreeComparatorTest.java
@@ -19,12 +19,42 @@
  */
 package org.sonar.scm.git.blame;
 
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class FileTreeComparatorTest {
+
+  @Test
+  void commonSubfolder_whenNoCommonSubfolder_thenEmpty() {
+    assertThat(FileTreeComparator.commonSubfolder(null)).isEmpty();
+    assertThat(FileTreeComparator.commonSubfolder(Set.of())).isEmpty();
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("fileA.txt"))).isEmpty();
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("domainA/fileA.txt", "domainB/fileB.txt"))).isEmpty();
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("domainA/fileA.txt", "domainAB/fileB.txt"))).isEmpty();
+  }
+
+  @Test
+  void commonSubfolder_whenSingleFileInSubfolder_thenReturnsItsFolder() {
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("domain/fileA.txt"))).contains("domain");
+  }
+
+  @Test
+  void commonSubfolder_whenNestedCommonFolder_thenReturnsDeepestSharedFolder() {
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("net/ethtool/a.c", "net/ethtool/b.c"))).contains("net/ethtool");
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("net/ethtool/a.c", "net/ethtool/sub/c.c"))).contains("net/ethtool");
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("domain/fileA.txt", "domain/fileB.txt", "domain/sub/fileC.txt")))
+      .contains("domain");
+  }
+
+  @Test
+  void commonSubfolder_ignoresNameOnlyPrefixThatIsNotADirectory() {
+    // "a/main..." and "a/maintenance..." share the string prefix "a/main" but their common directory is "a"
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("a/main/x.c", "a/maintenance/y.c"))).contains("a");
+    assertThat(FileTreeComparator.commonSubfolder(Set.of("a/main/x.c", "a/maintenance/y.c"))).isNotEqualTo(Optional.of("a/main"));
+  }
 
   @Test
   void isUnderCommonSubfolder_whenFilePathsIsNull_thenFalse() {

--- a/src/test/java/org/sonar/scm/git/blame/FileTreeComparatorTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FileTreeComparatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileTreeComparatorTest {
+
+  @Test
+  void isUnderCommonSubfolder_whenFilePathsIsNull_thenFalse() {
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(null)).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenFilePathsIsEmpty_thenFalse() {
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(Set.of())).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenSingleFileAtRoot_thenFalse() {
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(Set.of("fileA.txt"))).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenSingleFileInASubfolder_thenTrue() {
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(Set.of("domain/fileA.txt"))).isTrue();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenAllFilesShareASubfolder_thenTrue() {
+    Set<String> filePaths = Set.of("domain/fileA.txt", "domain/fileB.txt", "domain/sub/fileC.txt");
+
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(filePaths)).isTrue();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenFilesAreInDifferentTopLevelFolders_thenFalse() {
+    Set<String> filePaths = Set.of("domainA/fileA.txt", "domainB/fileB.txt");
+
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(filePaths)).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenFilesAreScatteredAtRoot_thenFalse() {
+    Set<String> filePaths = Set.of("fileA.txt", "fileB.txt", "domain/fileC.txt");
+
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(filePaths)).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenOneFileIsAtRootAndOthersAreNotDirectSiblings_thenFalse() {
+    Set<String> filePaths = Set.of("fileA.txt", "domain/fileB.txt", "domain/fileC.txt");
+
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(filePaths)).isFalse();
+  }
+
+  @Test
+  void isUnderCommonSubfolder_whenFilesShareANamePrefixButNotADirectory_thenFalse() {
+    // "domainA/..." and "domainB/..." share the string prefix "domain" but not a common directory
+    Set<String> filePaths = Set.of("domainA/fileA.txt", "domainAB/fileB.txt");
+
+    assertThat(FileTreeComparator.isUnderCommonSubfolder(filePaths)).isFalse();
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/PathScopedWalkIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/PathScopedWalkIT.java
@@ -1,0 +1,212 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.junit.jupiter.api.Test;
+import org.sonar.scm.git.blame.BlameResult.FileBlame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.scm.git.GitUtils.createFile;
+import static org.sonar.scm.git.GitUtils.deleteFile;
+import static org.sonar.scm.git.GitUtils.moveFile;
+
+/**
+ * The path-scoped walk is an optimization: it must produce exactly the same blame as the regular walk, only faster.
+ * These tests build histories that exercise the tricky cases - lots of commits that don't touch the blamed
+ * subfolder (which get skipped), a merge, and a rename inside the subfolder - and assert both walks agree
+ * line-for-line.
+ */
+class PathScopedWalkIT extends AbstractGitIT {
+
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_withNoiseCommitsAndInFolderRename() throws IOException, GitAPIException {
+    createFile(baseDir, "src/a.txt", "a-l1", "a-l2", "a-l3");
+    createFile(baseDir, "src/b.txt", "b-l1", "b-l2");
+    createFile(baseDir, "root.txt", "root-l1");
+    commit("src/a.txt", "src/b.txt", "root.txt");
+
+    // A long run of commits that never touch src/ - exactly what the path-scoped walk should skip over.
+    for (int i = 0; i < 20; i++) {
+      createFile(baseDir, "docs/doc" + i + ".txt", "doc " + i + " content");
+      commit("docs/doc" + i + ".txt");
+    }
+
+    createFile(baseDir, "src/a.txt", "a-l1", "a-l2-changed", "a-l3");
+    commit("src/a.txt");
+
+    for (int i = 0; i < 20; i++) {
+      createFile(baseDir, "root.txt", "root-l1", "root change " + i);
+      commit("root.txt");
+    }
+
+    // Rename inside the blamed subfolder, with a content change so it isn't a trivial blob-id match.
+    moveFile(baseDir, "src/b.txt", "src/b_renamed.txt");
+    createFile(baseDir, "src/b_renamed.txt", "b-l1", "b-l2", "b-l3-added");
+    commit("src/b.txt", "src/b_renamed.txt");
+
+    Set<String> blamed = Set.of("src/a.txt", "src/b_renamed.txt");
+    assertSameBlame(blamed);
+  }
+
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_acrossAMerge() throws IOException, GitAPIException {
+    createFile(baseDir, "src/a.txt", "a-l1", "a-l2");
+    createFile(baseDir, "src/c.txt", "c-l1");
+    String base = commit("src/a.txt", "src/c.txt");
+
+    // Feature branch touches src/, then diverges from main which only touches unrelated files.
+    createFile(baseDir, "src/a.txt", "a-l1-feature", "a-l2");
+    commit("src/a.txt");
+    String feature = git.getRepository().resolve("HEAD").getName();
+
+    resetHard(base);
+    for (int i = 0; i < 10; i++) {
+      createFile(baseDir, "other/o" + i + ".txt", "o " + i);
+      commit("other/o" + i + ".txt");
+    }
+    createFile(baseDir, "src/c.txt", "c-l1", "c-l2-main");
+    commit("src/c.txt");
+
+    merge(feature);
+
+    assertSameBlame(Set.of("src/a.txt", "src/c.txt"));
+  }
+
+  /**
+   * A diamond where both sides of a merge leave the blamed subfolder untouched, so both merge parents collapse
+   * towards the same ancestor. Exercises the case where naively collapsing a merge's parents would create
+   * duplicate parents and corrupt the region merging.
+   */
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_whenBothMergeSidesLeaveFolderUntouched() throws IOException, GitAPIException {
+    createFile(baseDir, "src/a.txt", "a-l1", "a-l2", "a-l3");
+    String base = commit("src/a.txt");
+
+    // Branch 1: only touches other/, never src/.
+    for (int i = 0; i < 5; i++) {
+      createFile(baseDir, "other/o" + i + ".txt", "o " + i);
+      commit("other/o" + i + ".txt");
+    }
+    String branch1 = git.getRepository().resolve("HEAD").getName();
+
+    // Branch 2 from base: only touches docs/, never src/.
+    resetHard(base);
+    for (int i = 0; i < 5; i++) {
+      createFile(baseDir, "docs/d" + i + ".txt", "d " + i);
+      commit("docs/d" + i + ".txt");
+    }
+
+    merge(branch1);
+
+    assertSameBlame(Set.of("src/a.txt"));
+  }
+
+  /**
+   * The blamed subfolder didn't exist earlier in history: the files were moved into it by a directory rename. The
+   * blame must follow the rename back to the old paths and attribute changes made there - the path-scoped walk must
+   * not skip over those commits just because the (current) subfolder is absent then.
+   */
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_whenSubfolderWasRenamedFromElsewhere() throws IOException, GitAPIException {
+    createFile(baseDir, "old/dir/a.txt", "a-l1", "a-l2", "a-l3");
+    commit("old/dir/a.txt");
+
+    // A change made while the file still lived under old/dir - blame must attribute a line here, not skip it.
+    createFile(baseDir, "old/dir/a.txt", "a-l1", "a-l2-changed-before-move", "a-l3");
+    commit("old/dir/a.txt");
+
+    // Directory rename: old/dir/a.txt -> new/dir/a.txt (the blamed subfolder new/dir appears only now).
+    createFile(baseDir, "new/dir/a.txt", "a-l1", "a-l2-changed-before-move", "a-l3");
+    deleteFile(baseDir, "old/dir/a.txt");
+    rm("old/dir/a.txt");
+    commit("old/dir/a.txt", "new/dir/a.txt");
+
+    createFile(baseDir, "new/dir/a.txt", "a-l1", "a-l2-changed-before-move", "a-l3", "a-l4-after-move");
+    commit("new/dir/a.txt");
+
+    for (int i = 0; i < 10; i++) {
+      createFile(baseDir, "unrelated/u" + i + ".txt", "u " + i);
+      commit("unrelated/u" + i + ".txt");
+    }
+
+    assertSameBlame(Set.of("new/dir/a.txt"));
+  }
+
+  /**
+   * A merge where the blamed file was created on one branch, so it looks added relative to the other parent and
+   * triggers the rename fallback there - but is carried unchanged by the branch that created it. The path-scoped
+   * rename fallback must recognise this and skip the full-repository diff, while still matching the regular blame.
+   */
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_whenBlamedFileAddedOnOneMergeBranch() throws IOException, GitAPIException {
+    createFile(baseDir, "src/existing.txt", "e-l1");
+    createFile(baseDir, "other/orig.txt", "m-l1", "m-l2");
+    String base = commit("src/existing.txt", "other/orig.txt");
+
+    // Feature branch creates src/feature.txt (a blamed file) and edits it.
+    createFile(baseDir, "src/feature.txt", "f-l1", "f-l2");
+    commit("src/feature.txt");
+    createFile(baseDir, "src/feature.txt", "f-l1", "f-l2-edited");
+    commit("src/feature.txt");
+    String feature = git.getRepository().resolve("HEAD").getName();
+
+    // Main branch only renames an unrelated file across folders (noise the fallback would otherwise chase).
+    resetHard(base);
+    createFile(baseDir, "lib/moved.txt", "m-l1", "m-l2");
+    deleteFile(baseDir, "other/orig.txt");
+    rm("other/orig.txt");
+    commit("lib/moved.txt", "other/orig.txt");
+
+    merge(feature);
+
+    assertSameBlame(Set.of("src/existing.txt", "src/feature.txt"));
+  }
+
+  private void assertSameBlame(Set<String> blamedPaths) throws GitAPIException {
+    BlameResult unscoped = blameWith(blamedPaths, false);
+    BlameResult scoped = blameWith(blamedPaths, true);
+    assertSameAs(unscoped, scoped, "path-scoped");
+  }
+
+  private BlameResult blameWith(Set<String> blamedPaths, boolean pathScoping) throws GitAPIException {
+    return new RepositoryBlameCommand(git.getRepository())
+      .setFilePaths(blamedPaths)
+      .setPathScoping(pathScoping)
+      .call();
+  }
+
+  private static void assertSameAs(BlameResult expected, BlameResult actual, String mode) {
+    Map<String, FileBlame> expectedByPath = expected.getFileBlameByPath();
+    Map<String, FileBlame> actualByPath = actual.getFileBlameByPath();
+
+    assertThat(actualByPath.keySet()).as("blamed paths (%s)", mode).isEqualTo(expectedByPath.keySet());
+    for (String path : expectedByPath.keySet()) {
+      FileBlame expectedBlame = expectedByPath.get(path);
+      FileBlame actualBlame = actualByPath.get(path);
+      assertThat(actualBlame.getCommitHashes()).as("commit hashes for %s (%s)", path, mode).isEqualTo(expectedBlame.getCommitHashes());
+      assertThat(actualBlame.getAuthorEmails()).as("author emails for %s (%s)", path, mode).isEqualTo(expectedBlame.getAuthorEmails());
+      assertThat(actualBlame.getCommitDates()).as("commit dates for %s (%s)", path, mode).isEqualTo(expectedBlame.getCommitDates());
+    }
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/PathScopedWalkIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/PathScopedWalkIT.java
@@ -183,6 +183,31 @@ class PathScopedWalkIT extends AbstractGitIT {
     assertSameBlame(Set.of("src/existing.txt", "src/feature.txt"));
   }
 
+  /**
+   * A file is renamed INTO an already-existing blamed subfolder from an outside path that was modified in a commit
+   * the path-scoped walk would collapse. The rename source's content changed in the skipped commit, so resolving the
+   * rename against the collapsed ancestor (instead of the real parent) would mis-attribute those lines. The
+   * path-scoped walk must still match the regular blame.
+   */
+  @Test
+  void pathScopedWalk_producesSameBlameAsRegularWalk_whenFileRenamedIntoFolderWithSourceEditedInCollapsedCommit() throws IOException, GitAPIException {
+    createFile(baseDir, "lib/x.txt", "l1", "l2");
+    createFile(baseDir, "src/keep.txt", "k1");
+    commit("lib/x.txt", "src/keep.txt");
+
+    // Edits the rename source while it still lives outside the blamed folder - this commit doesn't touch src/, so
+    // the path-scoped walk collapses it.
+    createFile(baseDir, "lib/x.txt", "l1", "l2-edited");
+    commit("lib/x.txt");
+
+    // Rename lib/x.txt -> src/x.txt into the pre-existing blamed folder, with no content change.
+    moveFile(baseDir, "lib/x.txt", "src/x.txt");
+    rm("lib/x.txt");
+    commit("lib/x.txt", "src/x.txt");
+
+    assertSameBlame(Set.of("src/x.txt", "src/keep.txt"));
+  }
+
   private void assertSameBlame(Set<String> blamedPaths) throws GitAPIException {
     BlameResult unscoped = blameWith(blamedPaths, false);
     BlameResult scoped = blameWith(blamedPaths, true);

--- a/src/test/java/org/sonar/scm/git/blame/perf/MonorepoBlamePerfIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/MonorepoBlamePerfIT.java
@@ -1,0 +1,116 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Not run as part of the default test task (see the "benchmark" Gradle task). Reproduces a customer-reported
+ * scenario: a large monorepo split into many domains (top-level directories), where only one domain's files are
+ * actually being analyzed via {@code RepositoryBlameCommand.setFilePaths(...)}, while most commits touch files in
+ * other, unrelated domains. Isolates the cost of computing the tree diff and rename detection over the WHOLE
+ * repository at every commit, instead of scoping it to the files actually being blamed.
+ */
+@Tag("benchmark")
+class MonorepoBlamePerfIT {
+  private static final long SEED = 42L;
+  private static final int WARMUP_RUNS = 1;
+  private static final int MEASURED_RUNS = 5;
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * 50 domains x 500 files (25 000 files total), only one domain (500 files) is blamed. Each commit touches 5
+   * random files across all domains, so the large majority of commits don't touch the blamed domain at all.
+   */
+  @Test
+  void blame_oneDomainOfManyInAMonorepo() throws IOException {
+    runScenario(new SyntheticRepoGenerator.MonorepoConfig(50, 500, 200, 3000, 5, SEED));
+  }
+
+  /**
+   * Same tracked domain (500 files), same history length and commit shape, but with no other domains at all - a
+   * control to isolate exactly how much the other 49 (untracked) domains cost in the scenario above.
+   */
+  @Test
+  void blame_singleDomainNoNoise_control() throws IOException {
+    runScenario(new SyntheticRepoGenerator.MonorepoConfig(1, 500, 200, 3000, 5, SEED));
+  }
+
+  private void runScenario(SyntheticRepoGenerator.MonorepoConfig config) throws IOException {
+    Path repoDir = tempDir.resolve("repo.git");
+
+    long generationStartNs = System.nanoTime();
+    SyntheticRepoGenerator.MonorepoStats stats = SyntheticRepoGenerator.generateMonorepo(repoDir, config);
+    long generationMs = (System.nanoTime() - generationStartNs) / 1_000_000;
+    System.out.printf("Generated repo: %d commits, %d domains x %d files (%d total, %d tracked) (%d ms)%n",
+      stats.numCommits(), stats.numDomains(), stats.filesPerDomain(), stats.totalFiles(), stats.trackedFiles().size(), generationMs);
+
+    List<Long> measuredMs = new ArrayList<>();
+    for (int i = 0; i < WARMUP_RUNS + MEASURED_RUNS; i++) {
+      long elapsedMs = runBlameAndMeasure(repoDir, stats.trackedFiles());
+      if (i < WARMUP_RUNS) {
+        System.out.printf("Warmup run: %d ms%n", elapsedMs);
+      } else {
+        System.out.printf("Measured run %d: %d ms%n", i - WARMUP_RUNS + 1, elapsedMs);
+        measuredMs.add(elapsedMs);
+      }
+    }
+
+    printSummary(measuredMs);
+  }
+
+  private long runBlameAndMeasure(Path repoDir, Set<String> trackedFiles) throws IOException {
+    try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+      long startNs = System.nanoTime();
+      BlameResult result = new RepositoryBlameCommand(repository).setFilePaths(trackedFiles).setMultithreading(true).call();
+      long elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+      assertThat(result.getFileBlames()).hasSize(trackedFiles.size());
+      return elapsedMs;
+    } catch (GitAPIException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static void printSummary(List<Long> measuredMs) {
+    List<Long> sorted = new ArrayList<>(measuredMs);
+    Collections.sort(sorted);
+    long min = sorted.get(0);
+    long median = sorted.get(sorted.size() / 2);
+    double avg = sorted.stream().mapToLong(Long::longValue).average().orElseThrow();
+    System.out.printf("Summary over %d measured runs: min=%dms median=%dms avg=%.1fms%n", sorted.size(), min, median, avg);
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/PathScopedWalkPerfIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/PathScopedWalkPerfIT.java
@@ -1,0 +1,102 @@
+/*
+ * Git Files Blame
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.scm.git.blame.perf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Not run as part of the default test task (see the "benchmark" Gradle task). Reproduces the situation observed on
+ * the Linux kernel: blaming a handful of files in one subfolder of a very large repository is dominated not by the
+ * per-commit tree diff (already scoped to the subfolder) but by the sheer number of commits the blame walks - the
+ * blamed subfolder is touched by only a small fraction of them, yet every ancestor is still visited.
+ *
+ * <p>The {@code commit iterations} reported here is the number of commits the walk actually processes (via the
+ * progress callback). The path-scoped walk should cut it down to roughly the number of commits that touch the
+ * blamed subfolder, and the wall-clock time with it. Both runs must produce identical blame.
+ */
+@Tag("benchmark")
+class PathScopedWalkPerfIT {
+  private static final long SEED = 42L;
+  private static final int WARMUP_RUNS = 1;
+  private static final int MEASURED_RUNS = 3;
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * 50 domains x 200 files (10 000 files), 6000 commits each touching 5 random files across all domains, so only
+   * ~1 commit in 10 touches the single blamed domain. A deep history where the blamed subfolder is a small slice.
+   */
+  @Test
+  void blame_subfolderOfDeepHistory() throws IOException {
+    Path repoDir = tempDir.resolve("repo.git");
+    SyntheticRepoGenerator.MonorepoStats stats = SyntheticRepoGenerator.generateMonorepo(repoDir,
+      new SyntheticRepoGenerator.MonorepoConfig(50, 200, 200, 6000, 5, SEED));
+    System.out.printf("Generated repo: %d commits, %d domains x %d files (%d total, %d tracked)%n",
+      stats.numCommits(), stats.numDomains(), stats.filesPerDomain(), stats.totalFiles(), stats.trackedFiles().size());
+
+    Result result = measure(repoDir, stats.trackedFiles());
+
+    assertThat(result.blamedFiles).isEqualTo(stats.trackedFiles().size());
+    System.out.printf("path-scoped blame: %d commit iterations, best %d ms over %d runs%n", result.iterations, result.bestMs, MEASURED_RUNS);
+  }
+
+  private static Result measure(Path repoDir, Set<String> trackedFiles) throws IOException {
+    long bestMs = Long.MAX_VALUE;
+    int iterations = 0;
+    int blamedFiles = 0;
+    for (int i = 0; i < WARMUP_RUNS + MEASURED_RUNS; i++) {
+      AtomicInteger iterationCounter = new AtomicInteger();
+      try (Repository repository = new FileRepositoryBuilder().setGitDir(repoDir.toFile()).build()) {
+        long startNs = System.nanoTime();
+        BlameResult result = new RepositoryBlameCommand(repository)
+          .setFilePaths(trackedFiles)
+          .setMultithreading(true)
+          .setProgressCallBack((iterationNb, commitHash) -> iterationCounter.incrementAndGet())
+          .call();
+        long elapsedMs = (System.nanoTime() - startNs) / 1_000_000;
+        if (i >= WARMUP_RUNS) {
+          bestMs = Math.min(bestMs, elapsedMs);
+        }
+        iterations = iterationCounter.get();
+        blamedFiles = result.getFileBlames().size();
+      } catch (GitAPIException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return new Result(iterations, bestMs, blamedFiles);
+  }
+
+  private record Result(int iterations, long bestMs, int blamedFiles) {
+  }
+}

--- a/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
+++ b/src/test/java/org/sonar/scm/git/blame/perf/SyntheticRepoGenerator.java
@@ -27,9 +27,11 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
@@ -114,6 +116,123 @@ public final class SyntheticRepoGenerator {
       pointHeadTo(repository, parentCommit);
       return new Stats(config.numFiles(), config.linesPerFile(), config.numCommits(), parentCommit);
     }
+  }
+
+  /**
+   * @param numDomains number of top-level directories the repository is split into, each getting its own subtree -
+   *                    mirrors a monorepo's directory layout, so a domain nobody touched in a given commit keeps
+   *                    the exact same subtree object id across commits, which is what lets a path-scoped tree diff
+   *                    skip over it without even looking inside
+   * @param filesPerDomain files per domain; {@code numDomains * filesPerDomain} files in total
+   * @param filesModifiedPerCommit how many files, picked at random from across ALL domains (not just the tracked
+   *                                one), get a one-line rewrite on each commit
+   */
+  public record MonorepoConfig(int numDomains, int filesPerDomain, int linesPerFile, int numCommits, int filesModifiedPerCommit, long seed) {
+    public int totalFiles() {
+      return numDomains * filesPerDomain;
+    }
+  }
+
+  /**
+   * @param trackedFiles every path belonging to the one domain a benchmark should pass to
+   *                      {@code RepositoryBlameCommand.setFilePaths(...)}, simulating analyzing a single
+   *                      subdirectory of a much larger monorepo
+   */
+  public record MonorepoStats(int numDomains, int filesPerDomain, int numCommits, ObjectId head, Set<String> trackedFiles) {
+    public int totalFiles() {
+      return numDomains * filesPerDomain;
+    }
+  }
+
+  public static MonorepoStats generateMonorepo(Path bareRepoDir, MonorepoConfig config) throws IOException {
+    Repository repository = new FileRepositoryBuilder().setGitDir(bareRepoDir.toFile()).build();
+    repository.create(true);
+
+    try (repository; ObjectInserter inserter = repository.newObjectInserter()) {
+      Random random = new Random(config.seed());
+
+      String[] domainNames = buildDomainNames(config.numDomains());
+      List<String> paths = new ArrayList<>(config.totalFiles());
+      Map<String, String[]> linesByPath = new HashMap<>();
+      Map<String, ObjectId> blobByPath = new HashMap<>();
+      Map<String, Set<String>> pathsByDomain = new HashMap<>();
+      for (String domain : domainNames) {
+        Set<String> domainPaths = new HashSet<>();
+        for (String fileName : buildSortedFileNames(config.filesPerDomain())) {
+          String path = domain + "/" + fileName;
+          paths.add(path);
+          domainPaths.add(path);
+          String[] lines = initialLines(path, config.linesPerFile());
+          linesByPath.put(path, lines);
+          blobByPath.put(path, insertBlob(inserter, lines));
+        }
+        pathsByDomain.put(domain, domainPaths);
+      }
+
+      Map<String, ObjectId> domainTreeIdByDomain = new HashMap<>();
+      for (String domain : domainNames) {
+        domainTreeIdByDomain.put(domain, buildDomainTree(inserter, pathsByDomain.get(domain), blobByPath));
+      }
+
+      ObjectId parentCommit = null;
+      Instant commitTime = Instant.parse("2015-01-01T00:00:00Z");
+      for (int commitIdx = 0; commitIdx < config.numCommits(); commitIdx++) {
+        Set<String> touchedDomains = new HashSet<>();
+        for (int modIdx = 0; modIdx < config.filesModifiedPerCommit(); modIdx++) {
+          String path = paths.get(random.nextInt(paths.size()));
+          rewriteRandomLine(inserter, linesByPath, blobByPath, path, random, commitIdx);
+          touchedDomains.add(domainOf(path));
+        }
+
+        for (String domain : touchedDomains) {
+          domainTreeIdByDomain.put(domain, buildDomainTree(inserter, pathsByDomain.get(domain), blobByPath));
+        }
+
+        ObjectId treeId = buildRootTree(inserter, domainNames, domainTreeIdByDomain);
+        PersonIdent ident = new PersonIdent("generator", "generator@example.com", commitTime, ZoneOffset.UTC);
+        parentCommit = createCommit(inserter, treeId, parentCommit, ident, "commit " + commitIdx);
+        commitTime = commitTime.plusSeconds(60);
+      }
+
+      inserter.flush();
+      pointHeadTo(repository, parentCommit);
+      return new MonorepoStats(config.numDomains(), config.filesPerDomain(), config.numCommits(), parentCommit, pathsByDomain.get(domainNames[0]));
+    }
+  }
+
+  private static String[] buildDomainNames(int numDomains) {
+    String[] names = new String[numDomains];
+    int digits = Integer.toString(Math.max(numDomains - 1, 1)).length();
+    for (int i = 0; i < numDomains; i++) {
+      names[i] = "domain" + zeroPad(i, digits);
+    }
+    return names;
+  }
+
+  private static String domainOf(String path) {
+    return path.substring(0, path.indexOf('/'));
+  }
+
+  private static ObjectId buildDomainTree(ObjectInserter inserter, Set<String> domainPaths, Map<String, ObjectId> blobByPath) throws IOException {
+    String[] sortedFileNames = domainPaths.stream().map(p -> p.substring(p.indexOf('/') + 1)).sorted().toArray(String[]::new);
+    String domain = domainOf(domainPaths.iterator().next());
+
+    TreeFormatter treeFormatter = new TreeFormatter();
+    for (String fileName : sortedFileNames) {
+      treeFormatter.append(fileName, FileMode.REGULAR_FILE, blobByPath.get(domain + "/" + fileName));
+    }
+    return inserter.insert(treeFormatter);
+  }
+
+  private static ObjectId buildRootTree(ObjectInserter inserter, String[] domainNames, Map<String, ObjectId> domainTreeIdByDomain) throws IOException {
+    String[] sortedDomains = domainNames.clone();
+    Arrays.sort(sortedDomains);
+
+    TreeFormatter treeFormatter = new TreeFormatter();
+    for (String domain : sortedDomains) {
+      treeFormatter.append(domain, FileMode.TREE, domainTreeIdByDomain.get(domain));
+    }
+    return inserter.insert(treeFormatter);
   }
 
   private static void rewriteRandomLine(ObjectInserter inserter, Map<String, String[]> linesByPath, Map<String, ObjectId> blobByPath, String path,


### PR DESCRIPTION
## Summary
A customer reported a first analysis taking 40 minutes to blame ~3800 files - the blame boundary-cache work (#107) doesn't help a first analysis (no prior cache to reuse), so this addresses the actual bottleneck directly: the customer's project is one subdirectory of Atlassian's much larger Jira monorepo. `SCM Publisher` accounted for 91% of the total analysis time, and the debug log showed the bulk blame algorithm processing 263K+ commits to resolve 3842 files - almost certainly because most of that history touches other parts of the monorepo entirely.

`FileTreeComparator` already has a path-scoped tree diff (`findMovedFilesWithPathFilter`, using JGit's `PathFilterGroup` + `TreeFilter.ANY_DIFF`) that lets JGit skip whole subtrees that didn't change between two commits - but it only kicked in when the number of blamed files was below a fixed threshold (`THRESHOLD_FILTER_FILES = 100`). For any project blaming more than ~100 files - which is most real projects, and certainly a 3842-file subdirectory - every commit fell through to computing the **full repository diff** plus rename detection over it, only filtering down to the blamed paths at the very end.

This replaces that file-count threshold with a decision made **once**, from the blame request itself: if every blamed file lives under some common subfolder of the repository, path-scoped diffing is applied regardless of how many files that is (`FileTreeComparator.isUnderCommonSubfolder`, computed from the longest common path prefix of the requested files). If blamed files are spread across the repository root - or it's a full-repository blame - most of the tree is relevant anyway, so scoping the diff has no upside and is skipped.

This fix is independent of #107 (the boundary cache) and doesn't need it - `RepositoryBlameCommand.setFilePaths(...)` is already called with just the files under the analyzed subdirectory in the current scanner-engine, which already share a common prefix. It would help this customer's *very first* analysis, not just subsequent ones.

## Benchmark results
New `MonorepoBlamePerfIT` scenario: 50 domains x 500 files (25,000 total), blaming only one domain (500 files), 3000 commits each touching 5 random files across all domains. Compared against the previous file-count threshold and a blunt "just raise the threshold" alternative:

| Scenario | Tracked/Total | Before | Raise threshold to 10,000 | This PR |
|---|---|---|---|---|
| Monorepo (the bug) | 500/25,000 | 3086 ms | 502 ms | **430 ms** |
| Control: one folder = 100% of repo | 500/500 | 1194 ms | 1332 ms | 1468 ms (known edge case, see below) |
| manyCommitsSmallFiles (root-level files) | 300/300 | 768 ms | 804 ms | **714 ms** |
| manyRenames (root-level files) | 500/500 | 4698 ms | 5069 ms | **4668 ms** |
| veryLargeRepository (root-level files) | 1000/1000 | 7650 ms | 8305 ms | **7390 ms** |
| fewCommitsLargeFiles (already under old threshold) | 50/50 | 1848 ms | 1818 ms | **1686 ms** |

Bolded rows are at or better than the original baseline - unlike a blunt threshold raise, this approach gets the full monorepo win (7.2x) with no regression on realistic "blaming basically the whole repo" scenarios, because the decision is a cheap one-time string-prefix check rather than a per-commit size comparison. The only remaining regression is a synthetic edge case where 100% of the repository's files live under one wrapper directory - uncommon in real repositories.

*("This PR" column rerun on 2026-07-21 against the latest commit, which also removes a redundant `collapseCache` lookup in `PathScopedWalk.collapse()` flagged in review - all medians over 5 measured runs, `veryLargeRepository` over 3.)*

## Test plan
- [x] `./gradlew test` passes, including new `FileTreeComparatorTest` unit tests for `isUnderCommonSubfolder` (null/empty, root-level files, shared subfolder at various depths, scattered top-level folders, files at root mixed with a subfolder, string-prefix-but-not-directory false positive)
- [x] `./gradlew benchmark --tests "*MonorepoBlamePerfIT*" --tests "*RepositoryBlamePerfIT*"` passes and reports the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Path-scoped walk optimization:**
    - Added `PathScopedWalk` to skip commits that do not modify the blamed subfolder, significantly reducing processing time in monorepos.
    - Integrated `PathScopedWalk` into `BlameGenerator` to collapse chains of non-touching commits between meaningful changes.
- **Performance metrics CLI:**
    - Introduced `git-files-blame` benchmark CLI to collect memory usage, GC stats, and wall-clock time for blame operations.
- **Optimized diff logic:**
    - Updated `FileTreeComparator` to support `cheapDiff` for scoped path filtering, preventing unnecessary full-repository rename detection.
    - Refactored `FileBlamer` to leverage `cheapDiff` for merge commits, allowing synthetic added-file entries when changes are covered by other merge parents.

<sub>This will update automatically on new commits.</sub>