### PR TITLE
GFB-49 Add picocli CLI to test and benchmark the blame library

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=cli/**,src/main/java/org/sonar/scm/git/blame/diff/**

--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,7 @@ artifactory {
 sonarqube {
     properties {
         property 'sonar.projectName', projectTitle
-        property "sonar.exclusions","src/main/java/org/sonar/scm/git/blame/diff/**"
+        property "sonar.exclusions","cli/**,src/main/java/org/sonar/scm/git/blame/diff/**"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+    id 'java'
+    id 'application'
+    id 'com.gradleup.shadow' version '9.0.0'
+}
+
+description = 'Command-line tool to test and benchmark the git-files-blame library'
+
+group = rootProject.group
+version = rootProject.version
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+jar {
+    manifest {
+        attributes('Implementation-Version': project.version)
+    }
+}
+
+repositories {
+    def repository = project.hasProperty('qa') ? 'sonarsource-qa' : 'sonarsource'
+    maven {
+        url = "https://repox.jfrog.io/repox/${repository}"
+        def artifactoryUsername = System.env.'ARTIFACTORY_PRIVATE_USERNAME' ?: (project.hasProperty('artifactoryUsername') ? project.getProperty('artifactoryUsername') : '')
+        def artifactoryPassword = System.env.'ARTIFACTORY_PRIVATE_PASSWORD' ?: (project.hasProperty('artifactoryPassword') ? project.getProperty('artifactoryPassword') : '')
+        if (artifactoryUsername && artifactoryPassword) {
+            credentials {
+                username = artifactoryUsername
+                password = artifactoryPassword
+            }
+        }
+    }
+}
+
+application {
+    mainClass = 'org.sonar.scm.git.blame.cli.BlameCliCommand'
+}
+
+dependencies {
+    implementation rootProject
+    // The library declares JGit as 'implementation', so it is not exposed transitively on our
+    // compile classpath. We use JGit types directly (Repository, TreeWalk, ...), hence a direct dependency.
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r'
+    implementation 'info.picocli:picocli:4.7.7'
+    // JGit 7.x depends on slf4j-api 2.x, so the logging binding must be a 2.x provider.
+    implementation 'org.slf4j:slf4j-api:2.0.16'
+    runtimeOnly 'org.slf4j:slf4j-simple:2.0.16'
+
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameCliCommand.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameCliCommand.java
@@ -85,9 +85,16 @@ public class BlameCliCommand implements Callable<Integer> {
     this.writeConcurrency = value;
   }
 
+  private long memorySampleIntervalMs = 50;
+
   @Option(names = "--memory-sample-interval-ms", defaultValue = "50",
     description = "Heap sampling interval in milliseconds. Default: ${DEFAULT-VALUE}.")
-  private long memorySampleIntervalMs;
+  private void setMemorySampleIntervalMs(long value) {
+    if (value < 1) {
+      throw new ParameterException(spec.commandLine(), "--memory-sample-interval-ms must be >= 1, but was " + value + ".");
+    }
+    this.memorySampleIntervalMs = value;
+  }
 
   @Override
   public Integer call() throws Exception {
@@ -104,12 +111,14 @@ public class BlameCliCommand implements Callable<Integer> {
 
       BlameRunResult blameRun = new BlameRunner()
         .run(repository, startCommitId, enumeration.filesToBlame(), !singleThreaded);
+
+      sampler.stop();
+      GcStats gc = GcStats.snapshot().minus(gcBefore);
+
       WriteResult writeResult = skipWriteOutput
         ? WriteResult.skipped()
         : new BlameOutputWriter().write(blameRun.blameResult().getFileBlames(), outputDir, writeConcurrency);
 
-      sampler.stop();
-      GcStats gc = GcStats.snapshot().minus(gcBefore);
       long totalDurationNanos = System.nanoTime() - totalStart;
 
       BenchmarkReport report = buildReport(located, startCommitId, enumeration, blameRun, writeResult,

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameCliCommand.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameCliCommand.java
@@ -1,0 +1,192 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.BlameResult.FileBlame;
+import org.sonar.scm.git.blame.cli.metrics.BenchmarkReport;
+import org.sonar.scm.git.blame.cli.metrics.GcStats;
+import org.sonar.scm.git.blame.cli.metrics.MemorySampler;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Entry point of the git-files-blame benchmark CLI. Blames every tracked file under a folder and
+ * collects timing, memory and volume measures into a report.
+ */
+@Command(
+  name = "git-files-blame",
+  mixinStandardHelpOptions = true,
+  versionProvider = ManifestVersionProvider.class,
+  description = "Blame all tracked files under a folder and collect benchmark measures.")
+public class BlameCliCommand implements Callable<Integer> {
+
+  private static final long BYTES_PER_MB = 1024L * 1024L;
+  private static final long NANOS_PER_MS = 1_000_000L;
+
+  @Parameters(index = "0", arity = "0..1", defaultValue = ".",
+    description = "Folder to blame. May be a sub-folder of a mono-repo. Default: current directory.")
+  private Path folder;
+
+  @Option(names = {"-o", "--output-dir"}, defaultValue = "blame-output",
+    description = "Directory where .blame files are written. Default: ${DEFAULT-VALUE}.")
+  private Path outputDir;
+
+  @Option(names = {"-e", "--exclude"}, paramLabel = "GLOB",
+    description = "Glob pattern of repo-relative paths to exclude. Repeatable, e.g. -e '**/*.min.js' -e 'gen/**'.")
+  private List<String> exclusions = new ArrayList<>();
+
+  @Option(names = "--single-threaded",
+    description = "Disable the library's multithreaded blame (multithreading is enabled by default).")
+  private boolean singleThreaded;
+
+  @Option(names = "--no-write-output",
+    description = "Skip writing .blame files, to measure blame time in isolation (files are written by default).")
+  private boolean skipWriteOutput;
+
+  @Nullable
+  @Option(names = "--start-commit", description = "Commit to start the blame from. Default: HEAD.")
+  private String startCommit;
+
+  @Nullable
+  @Option(names = "--label", description = "Label identifying this build in the report. Default: the CLI version.")
+  private String label;
+
+  @Nullable
+  @Option(names = "--report", description = "Path of the JSON report file. Default: <output-dir>/benchmark-report.json.")
+  private Path reportFile;
+
+  private int writeConcurrency = Runtime.getRuntime().availableProcessors();
+
+  @Spec
+  private CommandSpec spec;
+
+  @Option(names = "--write-concurrency", description = "Max number of files written concurrently. Default: number of CPUs.")
+  private void setWriteConcurrency(int value) {
+    if (value < 1) {
+      throw new ParameterException(spec.commandLine(), "--write-concurrency must be >= 1, but was " + value + ".");
+    }
+    this.writeConcurrency = value;
+  }
+
+  @Option(names = "--memory-sample-interval-ms", defaultValue = "50",
+    description = "Heap sampling interval in milliseconds. Default: ${DEFAULT-VALUE}.")
+  private long memorySampleIntervalMs;
+
+  @Override
+  public Integer call() throws Exception {
+    long totalStart = System.nanoTime();
+    LocatedRepository located = RepositoryLocator.locate(folder);
+    try (Repository repository = located.repository()) {
+      ObjectId startCommitId = resolveStartCommit(repository);
+      EnumerationResult enumeration = new FileEnumerator(exclusions)
+        .enumerate(repository, startCommitId, located.pathPrefix());
+
+      GcStats gcBefore = GcStats.snapshot();
+      MemorySampler sampler = new MemorySampler(memorySampleIntervalMs);
+      sampler.start();
+
+      BlameRunResult blameRun = new BlameRunner()
+        .run(repository, startCommitId, enumeration.filesToBlame(), !singleThreaded);
+      WriteResult writeResult = skipWriteOutput
+        ? WriteResult.skipped()
+        : new BlameOutputWriter().write(blameRun.blameResult().getFileBlames(), outputDir, writeConcurrency);
+
+      sampler.stop();
+      GcStats gc = GcStats.snapshot().minus(gcBefore);
+      long totalDurationNanos = System.nanoTime() - totalStart;
+
+      BenchmarkReport report = buildReport(located, startCommitId, enumeration, blameRun, writeResult,
+        sampler.peakHeapUsedBytes(), gc, totalDurationNanos);
+      emitReport(report);
+      return report.filesWriteFailed() == 0 ? 0 : 1;
+    }
+  }
+
+  private ObjectId resolveStartCommit(Repository repository) throws IOException {
+    String revision = startCommit != null ? startCommit : Constants.HEAD;
+    ObjectId resolved = repository.resolve(revision);
+    if (resolved == null) {
+      throw new IllegalStateException("Could not resolve start commit: " + revision);
+    }
+    return resolved;
+  }
+
+  private BenchmarkReport buildReport(LocatedRepository located, ObjectId startCommitId, EnumerationResult enumeration,
+    BlameRunResult blameRun, WriteResult writeResult, long peakHeapBytes, GcStats gc, long totalDurationNanos) {
+    BlameResult blameResult = blameRun.blameResult();
+    Path targetFolder = located.pathPrefix().isEmpty() ? located.workTree() : located.workTree().resolve(located.pathPrefix());
+    return new BenchmarkReport(
+      label != null ? label : ManifestVersionProvider.version(),
+      located.workTree().toString(),
+      targetFolder.toString(),
+      startCommitId.getName(),
+      enumeration.totalFilesInRepo(),
+      enumeration.filesUnderFolder(),
+      enumeration.filesExcluded(),
+      blameResult.getFileBlames().size(),
+      totalLines(blameResult),
+      blameRun.iterations(),
+      distinctCommits(blameResult),
+      blameRun.durationNanos() / NANOS_PER_MS,
+      writeResult.durationNanos() / NANOS_PER_MS,
+      totalDurationNanos / NANOS_PER_MS,
+      peakHeapBytes / BYTES_PER_MB,
+      Runtime.getRuntime().maxMemory() / BYTES_PER_MB,
+      gc.count(),
+      gc.timeMs(),
+      writeResult.filesFailed());
+  }
+
+  private void emitReport(BenchmarkReport report) throws IOException {
+    Path target = reportFile != null ? reportFile : outputDir.resolve("benchmark-report.json");
+    Path parent = target.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(target, report.toJson(), StandardCharsets.UTF_8);
+    System.out.print(report.toSummary());
+    System.out.println("Report written to " + target);
+  }
+
+  private static long totalLines(BlameResult blameResult) {
+    long total = 0;
+    for (FileBlame fileBlame : blameResult.getFileBlames()) {
+      total += fileBlame.lines();
+    }
+    return total;
+  }
+
+  private static int distinctCommits(BlameResult blameResult) {
+    Set<String> distinct = new HashSet<>();
+    for (FileBlame fileBlame : blameResult.getFileBlames()) {
+      for (String hash : fileBlame.getCommitHashes()) {
+        if (hash != null) {
+          distinct.add(hash);
+        }
+      }
+    }
+    return distinct.size();
+  }
+
+  public static void main(String[] args) {
+    int exitCode = new CommandLine(new BlameCliCommand()).execute(args);
+    System.exit(exitCode);
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameOutputWriter.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameOutputWriter.java
@@ -1,0 +1,103 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.LongAdder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.scm.git.blame.BlameResult.FileBlame;
+
+/**
+ * Writes each file's blame result to {@code outputDir/<relative path>.blame} using a virtual thread
+ * per file. This phase always runs after the blame computation, so it never affects the blame timing;
+ * it is still measured on its own.
+ */
+public class BlameOutputWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlameOutputWriter.class);
+  private static final String BLAME_SUFFIX = ".blame";
+
+  public WriteResult write(Collection<FileBlame> blames, Path outputDir, int concurrency) {
+    WriteJob job = new WriteJob(outputDir, new Semaphore(concurrency), new ConcurrentHashMap<>(),
+      new LongAdder(), new LongAdder(), new LongAdder());
+
+    long start = System.nanoTime();
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (FileBlame fileBlame : blames) {
+        executor.submit(() -> writeOne(fileBlame, job));
+      }
+    }
+    long durationNanos = System.nanoTime() - start;
+
+    return new WriteResult(durationNanos, job.written().intValue(), job.lines().sum(), job.failed().intValue());
+  }
+
+  private void writeOne(FileBlame fileBlame, WriteJob job) {
+    try {
+      job.semaphore().acquire();
+      try {
+        Path target = job.outputDir().resolve(fileBlame.getPath() + BLAME_SUFFIX);
+        ensureParentDir(target, job);
+        Files.write(target, render(fileBlame));
+        job.written().increment();
+        job.lines().add(fileBlame.lines());
+      } finally {
+        job.semaphore().release();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      job.failed().increment();
+    } catch (IOException | RuntimeException e) {
+      LOG.warn("Failed to write blame for {}", fileBlame.getPath(), e);
+      job.failed().increment();
+    }
+  }
+
+  private static void ensureParentDir(Path target, WriteJob job) {
+    Path parent = target.getParent();
+    if (parent == null) {
+      return;
+    }
+    // computeIfAbsent runs the creation at most once per directory and blocks concurrent callers
+    // for the same key until it completes, avoiding both redundant syscalls and write-before-mkdir races.
+    job.createdDirs().computeIfAbsent(parent, dir -> {
+      try {
+        Files.createDirectories(dir);
+        return Boolean.TRUE;
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    });
+  }
+
+  private static byte[] render(FileBlame fileBlame) {
+    String[] commitHashes = fileBlame.getCommitHashes();
+    Instant[] commitDates = fileBlame.getCommitDates();
+    String[] authorEmails = fileBlame.getAuthorEmails();
+
+    StringBuilder builder = new StringBuilder(fileBlame.lines() * 64);
+    for (int line = 0; line < fileBlame.lines(); line++) {
+      builder
+        .append(commitHashes[line] != null ? commitHashes[line] : "")
+        .append('\t')
+        .append(commitDates[line] != null ? commitDates[line].toString() : "")
+        .append('\t')
+        .append(authorEmails[line] != null ? authorEmails[line] : "")
+        .append('\n');
+    }
+    return builder.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private record WriteJob(Path outputDir, Semaphore semaphore, ConcurrentHashMap<Path, Boolean> createdDirs,
+    LongAdder written, LongAdder lines, LongAdder failed) {
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunResult.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunResult.java
@@ -1,0 +1,14 @@
+package org.sonar.scm.git.blame.cli;
+
+import org.sonar.scm.git.blame.BlameResult;
+
+/**
+ * Result of a timed blame execution.
+ *
+ * @param blameResult   the blame produced by the library
+ * @param durationNanos wall-clock duration of the {@code call()} in nanoseconds
+ * @param iterations    number of commit iterations reported by the progress callback (a commit may be
+ *                      visited more than once, so this is not a distinct-commit count)
+ */
+public record BlameRunResult(BlameResult blameResult, long durationNanos, int iterations) {
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunner.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunner.java
@@ -3,6 +3,7 @@ package org.sonar.scm.git.blame.cli;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.RawTextComparator;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.sonar.scm.git.blame.BlameResult;
@@ -20,6 +21,7 @@ public class BlameRunner {
       .setStartCommit(startCommit)
       .setFilePaths(filePaths)
       .setMultithreading(multithreading)
+      .setTextComparator(RawTextComparator.WS_IGNORE_ALL)
       .setProgressCallBack((iterationNb, commitHash) -> iterations.incrementAndGet());
 
     long start = System.nanoTime();

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunner.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/BlameRunner.java
@@ -1,0 +1,31 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonar.scm.git.blame.RepositoryBlameCommand;
+
+/**
+ * Runs {@link RepositoryBlameCommand} and measures the time it takes. The progress callback only
+ * increments a counter to keep the measured hot path as light as possible.
+ */
+public class BlameRunner {
+
+  public BlameRunResult run(Repository repository, ObjectId startCommit, Set<String> filePaths, boolean multithreading) throws GitAPIException {
+    AtomicInteger iterations = new AtomicInteger();
+    RepositoryBlameCommand command = new RepositoryBlameCommand(repository)
+      .setStartCommit(startCommit)
+      .setFilePaths(filePaths)
+      .setMultithreading(multithreading)
+      .setProgressCallBack((iterationNb, commitHash) -> iterations.incrementAndGet());
+
+    long start = System.nanoTime();
+    BlameResult blameResult = command.call();
+    long durationNanos = System.nanoTime() - start;
+
+    return new BlameRunResult(blameResult, durationNanos, iterations.get());
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/EnumerationResult.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/EnumerationResult.java
@@ -1,0 +1,14 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.util.Set;
+
+/**
+ * Outcome of enumerating the files to blame under a given folder.
+ *
+ * @param filesToBlame     repository-root-relative paths that will be blamed
+ * @param totalFilesInRepo total number of tracked files in the whole repository (mono-repo denominator)
+ * @param filesUnderFolder number of tracked files located under the target folder (before exclusions)
+ * @param filesExcluded    number of files under the folder that were dropped by exclusion globs
+ */
+public record EnumerationResult(Set<String> filesToBlame, int totalFilesInRepo, int filesUnderFolder, int filesExcluded) {
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/FileEnumerator.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/FileEnumerator.java
@@ -1,0 +1,81 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
+
+/**
+ * Enumerates the set of files to blame under a folder by walking the tree of the start commit.
+ * <p>
+ * Only committed (tracked) files are considered. This honors {@code .gitignore} by construction:
+ * ignored files (build outputs, dependencies, ...) are normally not committed, so they are never
+ * blamed. It also means untracked files are skipped, which is expected since they have no history
+ * to blame.
+ */
+public class FileEnumerator {
+
+  private final List<PathMatcher> exclusions;
+
+  public FileEnumerator(List<String> exclusionGlobs) {
+    this.exclusions = new ArrayList<>(exclusionGlobs.size());
+    for (String glob : exclusionGlobs) {
+      exclusions.add(FileSystems.getDefault().getPathMatcher("glob:" + glob));
+    }
+  }
+
+  public EnumerationResult enumerate(Repository repository, ObjectId startCommit, String pathPrefix) throws IOException {
+    Set<String> filesToBlame = new HashSet<>();
+    int totalFilesInRepo = 0;
+    int filesUnderFolder = 0;
+    int filesExcluded = 0;
+
+    try (RevWalk revWalk = new RevWalk(repository);
+      TreeWalk treeWalk = new TreeWalk(repository)) {
+      RevCommit commit = revWalk.parseCommit(startCommit);
+      treeWalk.addTree(commit.getTree());
+      treeWalk.setRecursive(true);
+
+      while (treeWalk.next()) {
+        if (!isFile(treeWalk.getRawMode(0))) {
+          continue;
+        }
+        totalFilesInRepo++;
+        String path = treeWalk.getPathString();
+        if (isUnderFolder(path, pathPrefix)) {
+          filesUnderFolder++;
+          if (isExcluded(path)) {
+            filesExcluded++;
+          } else {
+            filesToBlame.add(path);
+          }
+        }
+      }
+    }
+
+    return new EnumerationResult(filesToBlame, totalFilesInRepo, filesUnderFolder, filesExcluded);
+  }
+
+  private static boolean isUnderFolder(String path, String pathPrefix) {
+    return pathPrefix.isEmpty() || path.startsWith(pathPrefix);
+  }
+
+  private boolean isExcluded(String path) {
+    Path candidate = Path.of(path);
+    return exclusions.stream().anyMatch(matcher -> matcher.matches(candidate));
+  }
+
+  private static boolean isFile(int rawMode) {
+    return (rawMode & FileMode.TYPE_MASK) == FileMode.TYPE_FILE;
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/LocatedRepository.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/LocatedRepository.java
@@ -1,0 +1,15 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.nio.file.Path;
+import org.eclipse.jgit.lib.Repository;
+
+/**
+ * A git repository together with the location of the folder we want to blame inside it.
+ *
+ * @param repository the opened JGit repository (caller is responsible for closing it)
+ * @param workTree   the absolute, canonical path of the repository working tree root
+ * @param pathPrefix the target folder expressed as a repository-root-relative prefix using '/' separators.
+ *                   Empty when the target folder is the repository root, otherwise it ends with '/'.
+ */
+public record LocatedRepository(Repository repository, Path workTree, String pathPrefix) {
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/ManifestVersionProvider.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/ManifestVersionProvider.java
@@ -1,0 +1,20 @@
+package org.sonar.scm.git.blame.cli;
+
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Provides the version from the jar manifest ({@code Implementation-Version}), falling back to
+ * "dev" when running outside a packaged jar (e.g. from the IDE or tests).
+ */
+public class ManifestVersionProvider implements IVersionProvider {
+
+  static String version() {
+    String version = ManifestVersionProvider.class.getPackage().getImplementationVersion();
+    return version != null ? version : "dev";
+  }
+
+  @Override
+  public String[] getVersion() {
+    return new String[] {"git-files-blame CLI " + version()};
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/RepositoryLocator.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/RepositoryLocator.java
@@ -1,0 +1,43 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+/**
+ * Opens the git repository enclosing a given folder, even when that folder is nested deep inside a
+ * mono-repo. Also computes the repository-root-relative prefix of the folder so that only files under
+ * it are blamed.
+ */
+public final class RepositoryLocator {
+
+  private RepositoryLocator() {
+  }
+
+  public static LocatedRepository locate(Path folder) throws IOException {
+    Repository repository = new FileRepositoryBuilder()
+      .findGitDir(folder.toAbsolutePath().toFile())
+      .readEnvironment()
+      .build();
+    if (repository.getDirectory() == null) {
+      repository.close();
+      throw new IllegalArgumentException("No git repository found for folder: " + folder);
+    }
+
+    Path workTree = repository.getWorkTree().toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
+    Path absoluteFolder = folder.toRealPath(LinkOption.NOFOLLOW_LINKS);
+    if (!absoluteFolder.startsWith(workTree)) {
+      repository.close();
+      throw new IllegalArgumentException("Folder " + absoluteFolder + " is not inside the repository work tree " + workTree);
+    }
+
+    String prefix = workTree.relativize(absoluteFolder).toString().replace(File.separatorChar, '/');
+    if (!prefix.isEmpty() && !prefix.endsWith("/")) {
+      prefix += "/";
+    }
+    return new LocatedRepository(repository, workTree, prefix);
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/WriteResult.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/WriteResult.java
@@ -1,0 +1,16 @@
+package org.sonar.scm.git.blame.cli;
+
+/**
+ * Outcome of writing blame results to disk.
+ *
+ * @param durationNanos wall-clock duration of the whole write phase in nanoseconds
+ * @param filesWritten  number of {@code .blame} files successfully written
+ * @param linesWritten  total number of blame lines written across all files
+ * @param filesFailed   number of files that could not be written
+ */
+public record WriteResult(long durationNanos, int filesWritten, long linesWritten, int filesFailed) {
+
+  public static WriteResult skipped() {
+    return new WriteResult(0, 0, 0, 0);
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/BenchmarkReport.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/BenchmarkReport.java
@@ -1,0 +1,92 @@
+package org.sonar.scm.git.blame.cli.metrics;
+
+/**
+ * All the measures collected during a single benchmark run. Rendered both as a human-readable summary
+ * and as a JSON document so results from CLIs built on different branches can be compared.
+ */
+public record BenchmarkReport(
+  String label,
+  String repoRoot,
+  String targetFolder,
+  String startCommit,
+  int totalFilesInRepo,
+  int filesUnderFolder,
+  int filesExcluded,
+  int filesBlamed,
+  long totalLinesBlamed,
+  int commitIterations,
+  int distinctCommitsAttributed,
+  long blameDurationMs,
+  long writeDurationMs,
+  long totalDurationMs,
+  long peakHeapMb,
+  long maxHeapMb,
+  long gcCount,
+  long gcTimeMs,
+  int filesWriteFailed) {
+
+  public String toJson() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{\n");
+    appendString(builder, "label", label, true);
+    appendString(builder, "repoRoot", repoRoot, true);
+    appendString(builder, "targetFolder", targetFolder, true);
+    appendString(builder, "startCommit", startCommit, true);
+    appendNumber(builder, "totalFilesInRepo", totalFilesInRepo, true);
+    appendNumber(builder, "filesUnderFolder", filesUnderFolder, true);
+    appendNumber(builder, "filesExcluded", filesExcluded, true);
+    appendNumber(builder, "filesBlamed", filesBlamed, true);
+    appendNumber(builder, "totalLinesBlamed", totalLinesBlamed, true);
+    appendNumber(builder, "commitIterations", commitIterations, true);
+    appendNumber(builder, "distinctCommitsAttributed", distinctCommitsAttributed, true);
+    appendNumber(builder, "blameDurationMs", blameDurationMs, true);
+    appendNumber(builder, "writeDurationMs", writeDurationMs, true);
+    appendNumber(builder, "totalDurationMs", totalDurationMs, true);
+    appendNumber(builder, "peakHeapMb", peakHeapMb, true);
+    appendNumber(builder, "maxHeapMb", maxHeapMb, true);
+    appendNumber(builder, "gcCount", gcCount, true);
+    appendNumber(builder, "gcTimeMs", gcTimeMs, true);
+    appendNumber(builder, "filesWriteFailed", filesWriteFailed, false);
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  public String toSummary() {
+    return """
+      Benchmark report [%s]
+        repository            : %s
+        target folder         : %s
+        start commit          : %s
+        files in repo (total) : %d
+        files under folder    : %d
+        files excluded        : %d
+        files blamed          : %d
+        lines blamed          : %d
+        commit iterations     : %d
+        distinct commits      : %d
+        blame time            : %d ms
+        write time            : %d ms
+        total time            : %d ms
+        peak heap             : %d MB (max %d MB)
+        gc                    : %d collections, %d ms
+        write failures        : %d
+      """.formatted(label, repoRoot, targetFolder, startCommit, totalFilesInRepo, filesUnderFolder,
+      filesExcluded, filesBlamed, totalLinesBlamed, commitIterations, distinctCommitsAttributed,
+      blameDurationMs, writeDurationMs, totalDurationMs, peakHeapMb, maxHeapMb, gcCount, gcTimeMs,
+      filesWriteFailed);
+  }
+
+  private static void appendString(StringBuilder builder, String key, String value, boolean comma) {
+    builder.append("  \"").append(key).append("\": \"").append(escape(value)).append('"');
+    builder.append(comma ? ",\n" : "\n");
+  }
+
+  private static void appendNumber(StringBuilder builder, String key, long value, boolean comma) {
+    builder.append("  \"").append(key).append("\": ").append(value);
+    builder.append(comma ? ",\n" : "\n");
+  }
+
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/GcStats.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/GcStats.java
@@ -1,0 +1,33 @@
+package org.sonar.scm.git.blame.cli.metrics;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+
+/**
+ * Aggregated garbage collection statistics across all collectors.
+ *
+ * @param count  total number of collections
+ * @param timeMs total time spent collecting, in milliseconds
+ */
+public record GcStats(long count, long timeMs) {
+
+  public static GcStats snapshot() {
+    long count = 0;
+    long timeMs = 0;
+    for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      long beanCount = bean.getCollectionCount();
+      long beanTime = bean.getCollectionTime();
+      if (beanCount > 0) {
+        count += beanCount;
+      }
+      if (beanTime > 0) {
+        timeMs += beanTime;
+      }
+    }
+    return new GcStats(count, timeMs);
+  }
+
+  public GcStats minus(GcStats other) {
+    return new GcStats(count - other.count, timeMs - other.timeMs);
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/MemorySampler.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/MemorySampler.java
@@ -1,0 +1,65 @@
+package org.sonar.scm.git.blame.cli.metrics;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import javax.annotation.Nullable;
+
+/**
+ * Samples the used heap memory on a background daemon thread, keeping track of the peak observed
+ * value. Sampling runs within the JVM heap ceiling ({@code -Xmx}); set it explicitly for meaningful
+ * comparisons between runs.
+ */
+public class MemorySampler {
+
+  private final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+  private final long intervalMs;
+  private volatile boolean running;
+  private volatile long peakHeapUsedBytes;
+  @Nullable
+  private Thread thread;
+
+  public MemorySampler(long intervalMs) {
+    this.intervalMs = intervalMs;
+  }
+
+  public void start() {
+    peakHeapUsedBytes = 0;
+    running = true;
+    Thread sampler = new Thread(this::sampleLoop, "memory-sampler");
+    sampler.setDaemon(true);
+    sampler.start();
+    this.thread = sampler;
+  }
+
+  private void sampleLoop() {
+    while (running) {
+      long used = memoryBean.getHeapMemoryUsage().getUsed();
+      if (used > peakHeapUsedBytes) {
+        peakHeapUsedBytes = used;
+      }
+      try {
+        Thread.sleep(intervalMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  public void stop() {
+    running = false;
+    Thread sampler = this.thread;
+    if (sampler != null) {
+      sampler.interrupt();
+      try {
+        sampler.join(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  public long peakHeapUsedBytes() {
+    return peakHeapUsedBytes;
+  }
+}

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/package-info.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/metrics/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.sonar.scm.git.blame.cli.metrics;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/cli/src/main/java/org/sonar/scm/git/blame/cli/package-info.java
+++ b/cli/src/main/java/org/sonar/scm/git/blame/cli/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.sonar.scm.git.blame.cli;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/cli/src/test/java/org/sonar/scm/git/blame/cli/AbstractCliIT.java
+++ b/cli/src/test/java/org/sonar/scm/git/blame/cli/AbstractCliIT.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -26,6 +27,12 @@ abstract class AbstractCliIT {
     Repository repository = FileRepositoryBuilder.create(repoDir.resolve(".git").toFile());
     repository.create();
     git = new Git(repository);
+  }
+
+  @AfterEach
+  void tearDownRepository() {
+    git.getRepository().close();
+    git.close();
   }
 
   protected void writeFile(String relativePath, String content) throws IOException {

--- a/cli/src/test/java/org/sonar/scm/git/blame/cli/AbstractCliIT.java
+++ b/cli/src/test/java/org/sonar/scm/git/blame/cli/AbstractCliIT.java
@@ -1,0 +1,41 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Base class for CLI integration tests. Creates a throwaway git repository in a temp folder and
+ * exposes small helpers to add files and commits.
+ */
+abstract class AbstractCliIT {
+
+  @TempDir
+  protected Path repoDir;
+
+  protected Git git;
+
+  @BeforeEach
+  void setUpRepository() throws IOException {
+    Repository repository = FileRepositoryBuilder.create(repoDir.resolve(".git").toFile());
+    repository.create();
+    git = new Git(repository);
+  }
+
+  protected void writeFile(String relativePath, String content) throws IOException {
+    Path file = repoDir.resolve(relativePath);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+  }
+
+  protected void commitAll(String message) throws Exception {
+    git.add().addFilepattern(".").call();
+    git.commit().setCommitter("tester", "tester@example.com").setMessage(message).call();
+  }
+}

--- a/cli/src/test/java/org/sonar/scm/git/blame/cli/BlameCliCommandIT.java
+++ b/cli/src/test/java/org/sonar/scm/git/blame/cli/BlameCliCommandIT.java
@@ -1,0 +1,70 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BlameCliCommandIT extends AbstractCliIT {
+
+  @Test
+  void run_writesBlameFilesAndReport() throws Exception {
+    writeFile("README.md", "root\n");
+    writeFile("src/main/Foo.java", "line1\nline2\nline3\n");
+    writeFile("src/main/Bar.java", "only\n");
+    commitAll("initial");
+
+    Path outputDir = repoDir.resolve("out");
+    int exitCode = new CommandLine(new BlameCliCommand()).execute(
+      repoDir.resolve("src").toString(), "-o", outputDir.toString(), "--label", "unit-test");
+
+    assertThat(exitCode).isZero();
+
+    Path fooBlame = outputDir.resolve("src/main/Foo.java.blame");
+    Path barBlame = outputDir.resolve("src/main/Bar.java.blame");
+    assertThat(fooBlame).exists();
+    assertThat(barBlame).exists();
+    assertThat(Files.readAllLines(fooBlame)).hasSize(3);
+    assertThat(Files.readAllLines(barBlame)).hasSize(1);
+
+    Path report = outputDir.resolve("benchmark-report.json");
+    assertThat(report).exists();
+    String json = Files.readString(report);
+    assertThat(json)
+      .contains("\"label\": \"unit-test\"")
+      .contains("\"totalFilesInRepo\": 3")
+      .contains("\"filesBlamed\": 2")
+      .contains("\"totalLinesBlamed\": 4")
+      .contains("\"filesWriteFailed\": 0");
+  }
+
+  @Test
+  void run_withNonPositiveWriteConcurrency_failsInsteadOfHanging() throws Exception {
+    writeFile("src/Foo.java", "a\nb\n");
+    commitAll("initial");
+
+    Path outputDir = repoDir.resolve("out");
+    int exitCode = new CommandLine(new BlameCliCommand()).execute(
+      repoDir.resolve("src").toString(), "-o", outputDir.toString(), "--write-concurrency", "0");
+
+    assertThat(exitCode).isEqualTo(CommandLine.ExitCode.USAGE);
+    assertThat(outputDir.resolve("src/Foo.java.blame")).doesNotExist();
+  }
+
+  @Test
+  void run_withNoWriteOutput_doesNotWriteBlameFiles() throws Exception {
+    writeFile("src/Foo.java", "a\nb\n");
+    commitAll("initial");
+
+    Path outputDir = repoDir.resolve("out");
+    int exitCode = new CommandLine(new BlameCliCommand()).execute(
+      repoDir.resolve("src").toString(), "-o", outputDir.toString(), "--no-write-output");
+
+    assertThat(exitCode).isZero();
+    assertThat(outputDir.resolve("src/Foo.java.blame")).doesNotExist();
+    // the report is still produced
+    assertThat(outputDir.resolve("benchmark-report.json")).exists();
+  }
+}

--- a/cli/src/test/java/org/sonar/scm/git/blame/cli/FileEnumeratorIT.java
+++ b/cli/src/test/java/org/sonar/scm/git/blame/cli/FileEnumeratorIT.java
@@ -1,0 +1,67 @@
+package org.sonar.scm.git.blame.cli;
+
+import java.util.List;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileEnumeratorIT extends AbstractCliIT {
+
+  @Test
+  void enumerate_countsWholeRepoButBlamesOnlyFilesUnderFolder() throws Exception {
+    writeFile("README.md", "root\n");
+    writeFile("src/main/Foo.java", "a\nb\n");
+    writeFile("src/main/Bar.java", "c\n");
+    writeFile("other/Baz.java", "d\n");
+    commitAll("initial");
+
+    LocatedRepository located = RepositoryLocator.locate(repoDir.resolve("src"));
+    try (Repository repository = located.repository()) {
+      ObjectId head = repository.resolve("HEAD");
+      EnumerationResult result = new FileEnumerator(List.of()).enumerate(repository, head, located.pathPrefix());
+
+      assertThat(result.totalFilesInRepo()).isEqualTo(4);
+      assertThat(result.filesUnderFolder()).isEqualTo(2);
+      assertThat(result.filesExcluded()).isZero();
+      assertThat(result.filesToBlame()).containsExactlyInAnyOrder("src/main/Foo.java", "src/main/Bar.java");
+    }
+  }
+
+  @Test
+  void enumerate_appliesExclusionGlobs() throws Exception {
+    writeFile("src/main/Foo.java", "a\n");
+    writeFile("src/main/Bar.java", "b\n");
+    writeFile("src/generated/Gen.java", "c\n");
+    commitAll("initial");
+
+    LocatedRepository located = RepositoryLocator.locate(repoDir.resolve("src"));
+    try (Repository repository = located.repository()) {
+      ObjectId head = repository.resolve("HEAD");
+      EnumerationResult result = new FileEnumerator(List.of("**/generated/**", "**/Bar.java"))
+        .enumerate(repository, head, located.pathPrefix());
+
+      assertThat(result.filesUnderFolder()).isEqualTo(3);
+      assertThat(result.filesExcluded()).isEqualTo(2);
+      assertThat(result.filesToBlame()).containsExactly("src/main/Foo.java");
+    }
+  }
+
+  @Test
+  void enumerate_wholeRepoWhenFolderIsRoot() throws Exception {
+    writeFile("A.java", "a\n");
+    writeFile("sub/B.java", "b\n");
+    commitAll("initial");
+
+    LocatedRepository located = RepositoryLocator.locate(repoDir);
+    try (Repository repository = located.repository()) {
+      ObjectId head = repository.resolve("HEAD");
+      EnumerationResult result = new FileEnumerator(List.of()).enumerate(repository, head, located.pathPrefix());
+
+      assertThat(located.pathPrefix()).isEmpty();
+      assertThat(result.totalFilesInRepo()).isEqualTo(2);
+      assertThat(result.filesToBlame()).containsExactlyInAnyOrder("A.java", "sub/B.java");
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'git-files-blame'
+
+include 'cli'


### PR DESCRIPTION
New 'cli' Gradle subproject (Java 21, application + shadow fat jar) that blames every tracked file under a folder and collects benchmark measures.

- Honors .gitignore by enumerating only tracked files from the start-commit tree; supports glob exclusions and mono-repo sub-folders.
- Writes .blame files asynchronously on virtual threads, after (and timed separately from) the blame so output never affects the benchmark.
- Collects file/commit counts, blame/write/total durations, peak heap and GC stats into a stdout summary and a JSON report for per-branch comparison.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
