### PR TITLE
GFB-50 Fix blame failure on large repos with tracked files under gitignored folders

### DIFF
--- a/src/main/java/org/sonar/scm/git/blame/BlobReader.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlobReader.java
@@ -22,7 +22,9 @@ package org.sonar.scm.git.blame;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -138,8 +140,31 @@ public class BlobReader {
     }
   }
 
-  Map<String, Integer> getFileSizes(Set<String> files) throws IOException {
+  /**
+   * Compute the number of lines of each given file candidate.
+   * Candidates carrying a blob (i.e. anchored to a commit tree) are read from the object store, so that the size
+   * stays consistent with the tree being blamed. This matters for tracked files that are absent from the working
+   * directory, for example a committed file living under a {@code .gitignore}d folder: a working directory walk
+   * would prune it. Candidates without a blob represent working directory files and are read from disk.
+   */
+  Map<String, Integer> getFileSizes(ObjectReader objectReader, Collection<FileCandidate> candidates) throws IOException {
     Map<String, Integer> result = new HashMap<>();
+    Set<String> workingDirPaths = new HashSet<>();
+    for (FileCandidate candidate : candidates) {
+      if (ObjectId.zeroId().equals(candidate.getBlob())) {
+        workingDirPaths.add(candidate.getPath());
+      } else {
+        result.put(candidate.getPath(), loadText(objectReader, candidate.getBlob()).size());
+      }
+    }
+    addWorkingDirFileSizes(workingDirPaths, result);
+    return result;
+  }
+
+  private void addWorkingDirFileSizes(Set<String> files, Map<String, Integer> result) throws IOException {
+    if (files.isEmpty()) {
+      return;
+    }
     try (var treeWalk = new TreeWalk(repository)) {
       prepareTreeWalk(treeWalk);
       while (treeWalk.next()) {
@@ -150,7 +175,5 @@ public class BlobReader {
         }
       }
     }
-
-    return result;
   }
 }

--- a/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
+++ b/src/main/java/org/sonar/scm/git/blame/FileBlamer.java
@@ -93,10 +93,8 @@ public class FileBlamer {
   }
 
   private void initializeForLargeFileSet(ObjectReader objectReader, GraphNode commit) {
-
-    Set<String> filesToCheck = commit.getAllFiles().stream().map(FileCandidate::getPath).collect(Collectors.toSet());
     try {
-      Map<String, Integer> fileSizes = fileReader.getFileSizes(filesToCheck);
+      Map<String, Integer> fileSizes = fileReader.getFileSizes(objectReader, commit.getAllFiles());
       for (FileCandidate fileCandidate : commit.getAllFiles()) {
         Integer fileSize = fileSizes.get(fileCandidate.getPath());
         if (fileSize == null) {

--- a/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
@@ -21,10 +21,13 @@ package org.sonar.scm.git.blame;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,9 +90,12 @@ class BlameWithBareRepoIT extends AbstractGitIT {
     push();
 
     var reader = new BlobReader(bareRepoBlame.getRepository());
-    reader.getFileSizes(Set.of("file1", "file2"));
+    ObjectReader objectReader = bareRepoBlame.getRepository().newObjectReader();
+    List<FileCandidate> candidates = List.of(
+      new FileCandidate("file1", "file1", ObjectId.zeroId()),
+      new FileCandidate("file2", "file2", ObjectId.zeroId()));
 
-    assertThat(reader.getFileSizes(Set.of("file1", "file2"))).size().isEqualTo(2);
-    assertThat(reader.getFileSizes(Set.of("file1", "file2"))).containsOnly(entry("file1", 1), entry("file2", 2));
+    assertThat(reader.getFileSizes(objectReader, candidates)).size().isEqualTo(2);
+    assertThat(reader.getFileSizes(objectReader, candidates)).containsOnly(entry("file1", 1), entry("file2", 2));
   }
 }

--- a/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlobReaderIT.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.junit.jupiter.api.Test;
@@ -73,9 +72,12 @@ class BlobReaderIT extends AbstractGitIT {
 
 
     BlobReader reader = new BlobReader(git.getRepository());
-    reader.getFileSizes(Set.of("file1", "file2"));
+    ObjectReader objectReader = git.getRepository().newObjectReader();
+    List<FileCandidate> candidates = List.of(
+      new FileCandidate("file1", "file1", ObjectId.zeroId()),
+      new FileCandidate("file2", "file2", ObjectId.zeroId()));
 
-    assertThat(reader.getFileSizes(Set.of("file1", "file2"))).size().isEqualTo(2);
-    assertThat(reader.getFileSizes(Set.of("file1", "file2"))).containsOnly(entry("file1", 1), entry("file2", 2));
+    assertThat(reader.getFileSizes(objectReader, candidates)).size().isEqualTo(2);
+    assertThat(reader.getFileSizes(objectReader, candidates)).containsOnly(entry("file1", 1), entry("file2", 2));
   }
 }

--- a/src/test/java/org/sonar/scm/git/blame/FileBlamerTest.java
+++ b/src/test/java/org/sonar/scm/git/blame/FileBlamerTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -116,7 +115,7 @@ class FileBlamerTest {
     addFileCandidates(NB_FILES_THRESHOLD_ONE_TREE_WALK, statefulCommit);
 
     Map<String, Integer> filesize = statefulCommit.getAllFiles().stream().collect(Collectors.toMap(FileCandidate::getPath, f -> 30));
-    when(fileReader.getFileSizes(anySet())).thenReturn(filesize);
+    when(fileReader.getFileSizes(any(), any())).thenReturn(filesize);
 
     fileBlamer.initialize(objectReader, statefulCommit);
 
@@ -132,7 +131,7 @@ class FileBlamerTest {
     CommitGraphNode statefulCommit = new CommitGraphNode(revCommit, NB_FILES_THRESHOLD_ONE_TREE_WALK);
     addFileCandidates(NB_FILES_THRESHOLD_ONE_TREE_WALK, statefulCommit);
 
-    when(fileReader.getFileSizes(anySet())).thenThrow(new IOException());
+    when(fileReader.getFileSizes(any(), any())).thenThrow(new IOException());
 
     assertThatThrownBy(() -> fileBlamer.initialize(objectReader, statefulCommit)).isInstanceOf(IllegalStateException.class);
   }
@@ -150,7 +149,7 @@ class FileBlamerTest {
     Map<String, Integer> filesize = statefulCommit.getAllFiles().stream().collect(Collectors.toMap(FileCandidate::getPath, f -> 30));
     // Simulate a file is not present in the repository
     filesize.keySet().removeAll(filesize.keySet().stream().limit(1).collect(Collectors.toSet()));
-    when(fileReader.getFileSizes(anySet())).thenReturn(filesize);
+    when(fileReader.getFileSizes(any(), any())).thenReturn(filesize);
 
     assertThatThrownBy(() -> fileBlamer.initialize(objectReader, statefulCommit)).isInstanceOf(IllegalStateException.class);
   }

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -22,6 +22,7 @@ package org.sonar.scm.git.blame;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -32,6 +33,8 @@ import org.eclipse.jgit.api.BlameCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.RawTextComparator;
 import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.sonar.scm.git.blame.BlameResult.FileBlame;
 
@@ -506,6 +509,31 @@ class RepositoryBlameCommandIT extends AbstractGitIT {
 
     assertThat(result.getFileBlames()).extracting(FileBlame::getPath, FileBlame::getCommitHashes)
       .containsOnly(tuple("fileA", new String[]{c1, null}));
+  }
+
+  @Test
+  void blame_whenLargeFileSetIncludesTrackedFileUnderGitignoredFolder_thenBlameIt() throws IOException, GitAPIException {
+    // A committed file living under a .gitignore'd folder is invisible to a working directory walk, but it is still
+    // part of the commit tree. When the number of files exceeds NB_FILES_THRESHOLD_ONE_TREE_WALK, initialization
+    // must read its size from the object store, not from the working directory (which prunes ignored folders).
+    createFile(baseDir, "src/WEB-INF/classes/tracked", "line1");
+    String trackedCommit = commit("src/WEB-INF/classes/tracked");
+
+    createFile(baseDir, ".gitignore", "classes/");
+    commit(".gitignore");
+
+    List<String> paths = new ArrayList<>();
+    for (int i = 0; i < FileBlamer.NB_FILES_THRESHOLD_ONE_TREE_WALK; i++) {
+      createFile(baseDir, "file" + i, "line1");
+      paths.add("file" + i);
+    }
+    commit(paths.toArray(new String[0]));
+
+    ObjectId head = git.getRepository().resolve(Constants.HEAD);
+    BlameResult result = blame.setStartCommit(head).call();
+
+    assertThat(result.getFileBlames()).extracting(FileBlame::getPath, FileBlame::getCommitHashes)
+      .contains(tuple("src/WEB-INF/classes/tracked", new String[]{trackedCommit}));
   }
 
   private static void assertAllBlameCommits(BlameResult result, String expectedCommit) {


### PR DESCRIPTION
## Problem

Blaming a large repository fails with:

```
java.lang.IllegalStateException: Failed to find file in the working directory: private/branding/src/WEB-INF/classes/com/sonarsource/branding
        at org.sonar.scm.git.blame.FileBlamer.initializeForLargeFileSet(FileBlamer.java:103)
```

This is a pre-existing bug in the "one tree walk" optimization used when the number of files exceeds `NB_FILES_THRESHOLD_ONE_TREE_WALK` (50).

## Root cause

- In commit mode (a start commit is set, e.g. `HEAD`), file candidates come from the **commit tree** and carry the real blob object ids.
- `FileBlamer.initializeForLargeFileSet` obtained each file's size via `BlobReader.getFileSizes`, which walked the **working directory** with a `FileTreeIterator`.
- A standalone `FileTreeIterator` (not joined with a `DirCacheIterator`) **prunes any directory matching a `.gitignore` rule, even when it contains committed/tracked files**. `git check-ignore` reports such a file as *not* ignored (git never ignores tracked files), which makes the divergence surprising.
- The tracked file therefore existed in the commit tree but was invisible to the working-dir walk → its size was `null` → exception.

The smaller file-set path never hit this because it reads blobs by object id (`loadText(objectReader, fc.getBlob())`), consistent with the tree being blamed.

Reproducible on `sonar-enterprise`, which has tracked files under `.../WEB-INF/classes/` (root `.gitignore` contains `classes/`).

## Fix

`BlobReader.getFileSizes` now takes the `FileCandidate`s plus the `ObjectReader` and routes by blob:

- candidates with a blob (commit mode) → size read from the object store, staying consistent with the tree being blamed;
- zero-blob candidates (working-dir mode) → the single working-tree walk, as before.

## Tests

- Added `RepositoryBlameCommandIT.blame_whenLargeFileSetIncludesTrackedFileUnderGitignoredFolder_thenBlameIt`, reproducing the exact scenario (tracked file under a `.gitignore`d `classes/`, more than the threshold of files, commit mode).
- Updated `FileBlamerTest`, `BlobReaderIT`, `BlameWithBareRepoIT` for the new `getFileSizes` signature.
- Verified end-to-end against `sonar-enterprise`: all 14231 files now blame successfully (previously crashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)