### PR TITLE
GFB-51 Run the Gradle build on Windows in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,12 @@ jobs:
     runs-on: github-windows-latest-m
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Configure long paths
         run: git config --global core.longpaths true
-      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2025.7.12
       - uses: SonarSource/ci-github-actions/config-gradle@v1
@@ -68,7 +68,7 @@ jobs:
         run: ./gradlew check
       - name: Upload test reports on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-test-reports
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,38 @@ jobs:
           path: '**/test-results/**/*.xml'
           if-no-files-found: ignore
 
+  build-windows:
+    name: Build (Windows)
+    runs-on: github-windows-latest-m
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Configure long paths
+        run: git config --global core.longpaths true
+      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          version: 2025.7.12
+      - uses: SonarSource/ci-github-actions/config-gradle@v1
+        with:
+          artifactory-reader-role: private-reader
+      - name: Run Gradle check
+        run: ./gradlew check
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          if-no-files-found: ignore
+
   promote:
     needs:
       - build
+      - build-windows
     runs-on: github-ubuntu-latest-s
     name: Promote
     steps:

--- a/src/test/java/org/sonar/scm/git/GitUtils.java
+++ b/src/test/java/org/sonar/scm/git/GitUtils.java
@@ -43,7 +43,7 @@ public class GitUtils {
   public static void createFile(Path worktree, String relativePath, String... lines) throws IOException {
     Path newFile = worktree.resolve(relativePath);
     Files.createDirectories(newFile.getParent());
-    String content = String.join(System.lineSeparator(), lines) + System.lineSeparator();
+    String content = String.join("\n", lines) + "\n";
     Files.write(newFile, content.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
   }
 

--- a/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/AbstractGitIT.java
@@ -35,6 +35,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -53,6 +54,11 @@ abstract class AbstractGitIT {
     baseDir = createNewTempFolder();
     git = createRepository(baseDir);
     blame = new RepositoryBlameCommand(git.getRepository());
+  }
+
+  @AfterEach
+  void closeRepository() {
+    git.close();
   }
 
   /**

--- a/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/BlameWithBareRepoIT.java
@@ -29,6 +29,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.transport.URIish;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,11 @@ class BlameWithBareRepoIT extends AbstractGitIT {
       .call();
 
     bareRepoBlame = new RepositoryBlameCommand(bareGit.getRepository());
+  }
+
+  @AfterEach
+  void closeBareRepo() {
+    bareRepoBlame.getRepository().close();
   }
 
   private void push() throws GitAPIException {

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -499,7 +499,7 @@ class RepositoryBlameCommandIT extends AbstractGitIT {
   void blame_whenContentGiven_thenLinesHaveNullBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
-    String unsavedContent = String.join("\n", "line1", "newLine") + "\n";
+    String unsavedContent = "line1\nnewLine\n";
     UnaryOperator<String> fileAContentProvider = filePath -> "fileA".equals(filePath) ? unsavedContent : null;
 
     BlameResult result = blame

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -499,7 +499,7 @@ class RepositoryBlameCommandIT extends AbstractGitIT {
   void blame_whenContentGiven_thenLinesHaveNullBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");
     String c1 = commit("fileA");
-    String unsavedContent = String.join(System.lineSeparator(), "line1", "newLine") + System.lineSeparator();
+    String unsavedContent = String.join("\n", "line1", "newLine") + "\n";
     UnaryOperator<String> fileAContentProvider = filePath -> "fileA".equals(filePath) ? unsavedContent : null;
 
     BlameResult result = blame


### PR DESCRIPTION
## Summary
- Add a `build-windows` job to `.github/workflows/build.yml` that runs `./gradlew check` on `github-windows-latest-m`, catching platform-specific regressions (path separators, line endings, etc.) that the Linux-only build would miss.
- Follows the same pattern as `sonar-scanner-engine`'s Windows job: configure git long-paths, use the lighter `config-gradle` action (no deploy needed), upload test reports on failure.
- `promote` now also depends on `build-windows`.

## Test plan
- [ ] CI passes on this PR, including the new `build-windows` job

----
## Summary by Gitar

- **Infrastructure improvements:**
    - Added `build-windows` CI job using `github-windows-latest-m` to verify cross-platform compatibility.
    - Updated `promote` pipeline to include the new Windows build as a dependency.
- **Test environment fixes:**
    - Added `@AfterEach` hooks to `AbstractGitIT` and `BlameWithBareRepoIT` to ensure proper Git repository closure.
    - Standardized line endings in `GitUtils` and `RepositoryBlameCommandIT` using `
` to prevent platform-specific test failures.

<sub>This will update automatically on new commits.</sub>