### PR TITLE
GFB-42 Fix lost SonarQube coverage after Gradle/plugin upgrade

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -12,7 +12,8 @@ jobs:
       id-token: write
     # For external PR, ticket should be created manually
     if: |
-        github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository
+      && !startsWith(github.event.pull_request.title, 'NO-JIRA')
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ artifactory {
     clientConfig.info.addEnvironmentProperty('PROJECT_VERSION', "${version}")
 }
 
-sonarqube {
+sonar {
     properties {
         property 'sonar.projectName', projectTitle
         property "sonar.exclusions","cli/**,src/main/java/org/sonar/scm/git/blame/diff/**"
@@ -192,7 +192,7 @@ jacocoTestReport {
     }
 }
 
-tasks['sonarqube'].dependsOn jacocoTestReport
+tasks['sonar'].dependsOn jacocoTestReport
 
 signing {
     def signingKeyId = findProperty("signingKeyId")


### PR DESCRIPTION
## Summary
- The Gradle 9.6.1 upgrade bumped the `org.sonarqube` plugin from 3.3 to 7.2.2.6593. In that version, `sonar` is now an independent task from the deprecated `sonarqube` alias.
- `build.gradle` still wired `jacocoTestReport` and the analysis properties block to the old `sonarqube` task/extension, so CI's `sonar` task (used by `SonarSource/ci-github-actions/build-gradle@v1`) ran analysis without a fresh coverage report — explaining the coverage loss on master since the July 8th analysis.
- Fix: rename the `sonarqube {}` extension to `sonar {}`, and change `tasks['sonarqube'].dependsOn jacocoTestReport` to `tasks['sonar'].dependsOn jacocoTestReport`.

## Test plan
- [x] `./gradlew :sonar --dry-run` now includes `:jacocoTestReport` in the task graph (previously it did not).
- [x] `./gradlew test jacocoTestReport` produces `build/reports/jacoco/test/jacocoTestReport.xml` with real coverage counters.
- [ ] Confirm coverage reappears on the next SonarQube analysis of `master` after merge.

----
## Summary by Gitar

- **Build configuration:**
    - Updated `build.gradle` to migrate `sonarqube` task references and extension to `sonar` following the plugin upgrade.
- **CI workflow:**
    - Modified `.github/workflows/PullRequestCreated.yml` to prevent automated ticket creation when the PR title begins with the `NO-JIRA` prefix.

<sub>This will update automatically on new commits.</sub>