### PR TITLE
GFB-7 Fix duplicate key exception in BlameGenerator

### DIFF
--- a/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
+++ b/src/main/java/org/sonar/scm/git/blame/BlameGenerator.java
@@ -111,11 +111,15 @@ public class BlameGenerator {
       // From the merge commit, we'll traverse both branches, and we'll reach the commit before the fork twice
       // The solution is to merge all regions coming from both sides into that node.
       GraphNode existingCommit = queue.ceiling(newCommit);
+      // A GraphNode's own file list can already contain two candidates for the same (path, originalPath):
+      // rename/copy detection can independently resolve two different current-path candidates for the same
+      // original path onto the same ancestor path within a single blameParent/blameParents call. Merge those
+      // regions together rather than letting the collector reject the duplicate key.
       Map<PathAndOriginalPath, FileCandidate> newCommitFilesByPaths = newCommit.getAllFiles().stream()
-        .collect(Collectors.toMap(PathAndOriginalPath::new, f -> f));
+        .collect(Collectors.toMap(PathAndOriginalPath::new, f -> f, BlameGenerator::mergeCandidates));
 
       Map<PathAndOriginalPath, FileCandidate> existingCommitFilesByPaths = existingCommit.getAllFiles().stream()
-        .collect(Collectors.toMap(PathAndOriginalPath::new, f -> f));
+        .collect(Collectors.toMap(PathAndOriginalPath::new, f -> f, BlameGenerator::mergeCandidates));
 
       for (Map.Entry<PathAndOriginalPath, FileCandidate> newFiles : newCommitFilesByPaths.entrySet()) {
         if (existingCommitFilesByPaths.containsKey(newFiles.getKey())) {
@@ -127,6 +131,11 @@ public class BlameGenerator {
     } else {
       queue.add(newCommit);
     }
+  }
+
+  private static FileCandidate mergeCandidates(FileCandidate a, FileCandidate b) {
+    a.mergeRegions(b);
+    return a;
   }
 
   public void generateBlame(ObjectId startCommit) throws IOException, NoHeadException {

--- a/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
+++ b/src/test/java/org/sonar/scm/git/blame/RepositoryBlameCommandIT.java
@@ -495,6 +495,84 @@ class RepositoryBlameCommandIT extends AbstractGitIT {
     assertAllBlameCommits(result, c1);
   }
 
+  /**
+   * Reproduces https://sonarsource.atlassian.net/browse/GFB-7 : a "Duplicate key" IllegalStateException
+   * thrown by BlameGenerator.push() when a single blameParent call maps two different current-path
+   * candidates for the same original path onto the same ancestor path.
+   * <pre>
+   *      c0(root,w)
+   *      /        \
+   * c1a(fileA,fileB)  c1w(w modified, root deleted)
+   *   /        \                |
+   * c2(fileA)  c3(fileB)        |
+   *      \      \               |
+   *       \    c3b(fileB renamed to fileA)
+   *        \    /                |
+   *        c4(fileA)-------------
+   *              \
+   *              c5(fileA,w)  <--- HEAD
+   * </pre>
+   * root is deleted in c1a and replaced by two exact copies of its content, fileA and fileB: the rename
+   * detector pairs one of them as a RENAME and the other as a COPY, but both share the same old path
+   * "root". fileA's blamed regions independently split across c2 and c3/c3b, then reconverge at c4, so c1a
+   * ends up holding two candidates for the same original path at two different current paths (fileA and
+   * fileB). When c1a is diffed against its own parent c0 in a single blameParent call, both of those
+   * candidates independently resolve to path "root", producing two FileCandidate entries with an identical
+   * (path, originalPath) key before push()'s queue-revisit merge (designed only for collisions arriving
+   * from two separate calls) ever gets a chance to run.
+   */
+  @Test
+  void blame_whenTwoDifferentPathsIndependentlyRenameFromTheSameAncestorPath_thenRegionsShouldMerge() throws IOException, GitAPIException {
+    // Explicit, strictly increasing timestamps: BlameGenerator's traversal queue orders commits by time,
+    // and same-second (default "now") timestamps on rapid-fire test commits can tie, breaking revisit
+    // detection in a way unrelated to the bug this test targets.
+    long t = 1_700_000_000_000L;
+
+    createFile(baseDir, "root", "line1", "line2", "line3", "line4");
+    createFile(baseDir, "w", "w1");
+    String c0 = commit(t += 60_000, ".");
+
+    rm("root");
+    createFile(baseDir, "fileA", "line1", "line2", "line3", "line4");
+    createFile(baseDir, "fileB", "line1", "line2", "line3", "line4");
+    commit(t += 60_000, ".");
+    String c1a = git.getRepository().resolve(Constants.HEAD).getName();
+
+    createFile(baseDir, "fileA", "line1", "line2");
+    rm("fileB");
+    String c2 = commit(t += 60_000, ".");
+
+    resetHard(c1a);
+    createFile(baseDir, "fileB", "line3", "line4");
+    rm("fileA");
+    commit(t += 60_000, ".");
+
+    rm("fileB");
+    createFile(baseDir, "fileA", "line3", "line4");
+    commit(t += 60_000, "fileA");
+
+    merge(c2);
+    rm("fileB");
+    createFile(baseDir, "fileA", "line1", "line2", "line3", "line4");
+    git.add().addFilepattern("fileA").call();
+    String c4 = commit(t += 60_000);
+
+    resetHard(c0);
+    rm("root");
+    createFile(baseDir, "w", "w1", "w2");
+    String c1w = commit(t += 60_000, ".");
+
+    resetHard(c4);
+    merge(c1w);
+
+    BlameResult result = blame.call();
+
+    assertThat(result.getFileBlames()).extracting(FileBlame::getPath, FileBlame::getCommitHashes)
+      .containsOnly(
+        tuple("fileA", new String[] {c0, c0, c0, c0}),
+        tuple("w", new String[] {c0, c1w}));
+  }
+
   @Test
   void blame_whenContentGiven_thenLinesHaveNullBlame() throws IOException, GitAPIException {
     createFile(baseDir, "fileA", "line1");


### PR DESCRIPTION
## Summary
- Fixes [GFB-7](https://sonarsource.atlassian.net/browse/GFB-7) / the [community-reported "duplicate key" crash](https://community.sonarsource.com/t/sonarscanner-fails-with-duplicate-key-exception-in-the-blamegenerator/101538) in `BlameGenerator`.
- Root cause: within a single `blameParent`/`blameParents` call, rename/copy detection can resolve two different current-path candidates for the same original blamed path onto the *same* ancestor path (e.g. one delete matched by two competing adds — one becomes a `RENAME`, the other a `COPY`, both sharing the old path). This produces two `FileCandidate`s with an identical `(path, originalPath)` key before `push()`'s queue-revisit merge logic (which only expected duplicates arising from two *separate* `push()` calls) ever runs, and the plain `Collectors.toMap` throws `IllegalStateException: Duplicate key ...`.
- Fix: supply a merge function (reusing `FileCandidate.mergeRegions`) to both `Collectors.toMap` calls in `BlameGenerator.push()`, so such in-call collisions merge instead of throwing.

## Test plan
- [x] Added `RepositoryBlameCommandIT#blame_whenTwoDifferentPathsIndependentlyRenameFromTheSameAncestorPath_thenRegionsShouldMerge`, which constructs the exact git topology (merge-fork on two exact-content-copies of a deleted file, converging back through rename/copy detection) and reproduces the reported exception verbatim before the fix, and asserts correct merged blame after it.
- [x] Full existing test suite passes (`./gradlew test`), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GFB-7]: https://sonarsource.atlassian.net/browse/GFB-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ